### PR TITLE
Challenges list page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,9 +39,13 @@ const router = createBrowserRouter([
         element: <Home />,
       },
       {
+        path: "challenges",
+        element: <Challenges />,
+      },
+      {
         path: "challenge/:id",
-        element: <Challenge />
-      }
+        element: <Challenge />,
+      },
     ],
   },
 ]);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Home from "./pages/Home.tsx";
 import AppShell from "./components/AppShell.tsx";
 import ErrorElement from "./pages/ErrorElement.tsx";
+import Challenges from "./pages/Challenges.tsx";
 import Challenge from "./pages/Challenge.tsx";
 
 const NAV_CONFIG = {

--- a/client/src/components/ChallengeCard.tsx
+++ b/client/src/components/ChallengeCard.tsx
@@ -1,10 +1,9 @@
-import Card from "react-bootstrap/Card";
+  import Card from "react-bootstrap/Card";
 import Button from "./Button.tsx";
 import { StarFill } from "react-bootstrap-icons";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort.ts";
-// TODO: extract challenge into its own type
 import { Link } from "react-router-dom";
-
+import { useCallback } from "react";
 
 function ChallengeCard({
   title,
@@ -13,19 +12,14 @@ function ChallengeCard({
   difficulty,
 }: ChallengeDetailsShort) {
 
-  function getDifficulty(): JSX.Element[] {
-    const difficultyList: JSX.Element[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    for (let i = 0; i <= difficulty; i++) {
-      difficultyList.push(<StarFill key={i} />);
-    }
-    return difficultyList;
-  }
+  const getDifficultyStars = useCallback((difficulty: number) => {
+    return Array.from({ length: difficulty + 1 }, (_, i) => <StarFill key={i} />);
+  }, [difficulty]);
 
   return (
     <Card>
       <Card.Header>
-        {getDifficulty()}
+         {getDifficultyStars(difficulty)}
       </Card.Header>
       <Card.Body>
         <Card.Title>{title}</Card.Title>

--- a/client/src/components/ChallengeCard.tsx
+++ b/client/src/components/ChallengeCard.tsx
@@ -1,49 +1,39 @@
 import Card from "react-bootstrap/Card";
 import Button from "./Button.tsx";
 import { StarFill } from "react-bootstrap-icons";
-
-enum Difficulty {
-  easy = "easy",
-  medium = "medium",
-  hard = "hard",
-}
-
+import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort.ts";
 // TODO: extract challenge into its own type
 
-type ChallengeCardProps = {
-  title: string;
-  description: string;
-  href: string;
-  difficulty: Difficulty;
-};
 
-const DIFFICULTY_TO_STARCOUNT = {
-  easy: 1,
-  medium: 2,
-  hard: 3,
-};
 
 function ChallengeCard({
   title,
-  description,
-  href,
+  generalDescription,
+  id,
   difficulty,
-}: ChallengeCardProps) {
+}: ChallengeDetailsShort) {
+
+  function getDifficulty(): JSX.Element[] {
+    const difficultyList: JSX.Element[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    for (let i = 0; i <= difficulty; i++) {
+      difficultyList.push(<StarFill key={i} />);
+    }
+    return difficultyList;
+  }
+
   return (
     <Card>
       <Card.Header>
-        {Array(DIFFICULTY_TO_STARCOUNT[difficulty]).map((_, index) => (
-          <StarFill key={index} />
-        ))}
+        {getDifficulty()}
       </Card.Header>
       <Card.Body>
         <Card.Title>{title}</Card.Title>
-        <Card.Text>{description}</Card.Text>
-        <Button href={href}>Solve</Button>
+        <Card.Text>{generalDescription}</Card.Text>
+        <Button href={"/challenge/" + id}>Solve</Button>
       </Card.Body>
     </Card>
   );
 }
 
-export type { ChallengeCardProps };
 export default ChallengeCard;

--- a/client/src/components/ChallengeCard.tsx
+++ b/client/src/components/ChallengeCard.tsx
@@ -3,7 +3,7 @@ import Button from "./Button.tsx";
 import { StarFill } from "react-bootstrap-icons";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort.ts";
 // TODO: extract challenge into its own type
-
+import { Link } from "react-router-dom";
 
 
 function ChallengeCard({
@@ -30,7 +30,11 @@ function ChallengeCard({
       <Card.Body>
         <Card.Title>{title}</Card.Title>
         <Card.Text>{generalDescription}</Card.Text>
-        <Button href={"/challenge/" + id}>Solve</Button>
+        <Link style={{textDecoration: "none"}} to={"/challenge/" + id}>
+          <Button>
+            Solve
+          </Button>
+        </Link>
       </Card.Body>
     </Card>
   );

--- a/client/src/components/ChallengeCard.tsx
+++ b/client/src/components/ChallengeCard.tsx
@@ -1,4 +1,4 @@
-  import Card from "react-bootstrap/Card";
+import Card from "react-bootstrap/Card";
 import Button from "./Button.tsx";
 import { StarFill } from "react-bootstrap-icons";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort.ts";

--- a/client/src/components/DifficultyBadge.tsx
+++ b/client/src/components/DifficultyBadge.tsx
@@ -1,7 +1,7 @@
 import { ChallengeDifficulties } from '../types/challengeDifficulties';
 import { Badge } from 'react-bootstrap';
 
-export function getDifficulty(difficulty: ChallengeDifficulties): string{
+function getDifficulty(difficulty: ChallengeDifficulties): string{
     switch(difficulty){
         case ChallengeDifficulties.EASY:
             return "success";

--- a/client/src/components/DifficultyBadge.tsx
+++ b/client/src/components/DifficultyBadge.tsx
@@ -1,3 +1,5 @@
+// Currently not used in the application
+
 import { ChallengeDifficulties } from '../types/challengeDifficulties';
 import { Badge } from 'react-bootstrap';
 

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -30,7 +30,7 @@ const Challenge = () => {
             if(!response.ok){
                 throw new Error(response.statusText);                
             }
-            return response.json() as Promise<ChallengeDetails>; //THIS LINE MAY CAUSE ERRORS. Need to test with proper server.
+            return response.json() as Promise<ChallengeDetails>;
         }).then((data) => {
             setDetails(data);
             setIsLoading(false);

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHeader, AccordionBody, Accordion } from "react-bootstrap";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
 import DifficultyBadge from "../components/DifficultyBadge";
+import { StarFill } from "react-bootstrap-icons";
 
 
 const Challenge = () => {
@@ -35,17 +36,21 @@ const Challenge = () => {
         });
    }, [id]);
 
+    const getDifficultyStars = useCallback((difficulty: number) => {
+        return Array.from({ length: difficulty + 1 }, (_, i) => <StarFill key={i} />);
+    }, [details]);
+
     if (isLoading) return <p>Loading...</p>;
     if (details == undefined) return <p>Failed to load challenge details</p>;
     return (
     <Container>
         <section>
         <Row>
-            <header className="text-center  bg-dark text-light p-5 pb-3 mb-4 mt-2">
-                <h1 className="fw-semibold" >{details.title}</h1>
-                <h2 className=" text-light fw-normal fs-3">{details.outcome}</h2>
-                <div className="mt-4 me-n4">
-                    <DifficultyBadge difficulty={details.difficulty}></DifficultyBadge>
+            <header className="text-center bg-secondary-subtle text-dark p-5 pb-3 mb-4 mt-2">
+                <h1 className="fw-bold" >{details.title}</h1>
+                <h2 className=" text-dark fw-semibold fs-3">{details.outcome}</h2>
+                <div className="mt-4 me-n4 float-end">
+                    {getDifficultyStars(details.difficulty)}
                 </div>
             </header> 
         </Row>
@@ -70,7 +75,7 @@ const Challenge = () => {
                         <AccordionBody>
                             <ul>
                                 {details.keyPatterns.map((pattern, index) => {
-                                    return <li key={index}>{pattern + (pattern[-1] != "." && ".")}</li>
+                                    return <li key={index}>{pattern + (pattern[-1] !== "." && ".")}</li>
                                 })}
                             </ul>
                         </AccordionBody>

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -2,10 +2,18 @@
 
 import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHeader, AccordionBody, Accordion } from "react-bootstrap";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
 import { ChallengeDifficulties } from "../types/challengeDifficulties";
 import DifficultyBadge from "../components/DifficultyBadge";
+
+function useScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+}
 
 const Challenge = () => {
     //TODO: Fetch this value from the server
@@ -15,6 +23,7 @@ const Challenge = () => {
 
     const { id } = useParams();
 
+    useScrollToTop();
 
     //TODO: Refactor once the API is ready
     //TODO: Refactor once the API is ready

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -4,13 +4,12 @@ import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHea
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
-import DifficultyBadge from "../components/DifficultyBadge";
 import { StarFill } from "react-bootstrap-icons";
 
 
 const Challenge = () => {
     //TODO: Fetch this value from the server
-    const [completed, setCompleted] = useState(true); //TODO: This value should be fetched from the server
+    const [completed, setCompleted] = useState(false); //TODO: This value should be fetched from the server
     const [details, setDetails] = useState<ChallengeDetails>();
     const [isLoading, setIsLoading] = useState(true);
 
@@ -49,48 +48,20 @@ const Challenge = () => {
             <header className="text-center bg-secondary-subtle text-dark p-5 pb-3 mb-4 mt-2">
                 <h1 className="fw-bold" >{details.title}</h1>
                 <h2 className=" text-dark fw-semibold fs-3">{details.outcome}</h2>
-                <div className="mt-4 me-n4 float-end">
+                <div className="mt-4 me-n4 float-start ">
                     {getDifficultyStars(details.difficulty)}
                 </div>
+                {completed && <span className=" mt-4 float-end text-success">
+                    <strong>Completed</strong>
+                </span>}
             </header> 
         </Row>
-        <Row >
-            <Col xl={{offset: 11}}>
-            </Col>
-        </Row>
-        {completed &&
         <Row>
-            {/* If completed, allow to view design patterns. */}
-            <Col xl={{span:2, order:2}}> 
-                <span className="fs-5 mb-2 float-end text-success">
-                    <strong>Completed</strong>
-                </span>
-            </Col>
-            <Col xl={{span:10, order: 1}}>
-                <Accordion className="mb-2">
-                    <AccordionItem eventKey="0">
-                        <AccordionHeader className="fs-4">
-                            <h3 className="fs-4">Key Design Patterns</h3>
-                        </AccordionHeader>
-                        <AccordionBody>
-                            <ul>
-                                {details.keyPatterns.map((pattern, index) => {
-                                    return <li key={index}>{pattern + (pattern[-1] !== "." && ".")}</li>
-                                })}
-                            </ul>
-                        </AccordionBody>
-                    </AccordionItem>
-                </Accordion>
-            </Col>
-        </Row>}
-        <Row >
-            <Col xl={10} >
+            <Col lg={{span: 6, offset: 0}} xl={{span: 5, offset: 1}}>
                 <h3 className="fs-4">Description:</h3>
                 <p>{details.generalDescription}</p>
             </Col>
-        </Row>
-        <Row>
-            <Col xl={10}>
+            <Col lg={6} xl={5}>
                 <h3 className="fs-4">Expected functionality:</h3>
                 <ul>    
                     {Object.entries(details.expectedFunctionality).map(([key, value]) => {
@@ -99,8 +70,8 @@ const Challenge = () => {
                 </ul>
             </Col>
         </Row>
-        <Row>
-            <Col xl={10}>
+        <Row className={!completed ? "align-items-end": ""}> 
+            <Col lg={{span: 6, offset: 0}} xl={{span: 5, offset: 1}}>
             <h3 className="fs-4">Usage Scenarios</h3>
             <ul>
             {Object.entries(details.usageScenarios).map(([key, value]) => {
@@ -108,14 +79,37 @@ const Challenge = () => {
                 })}  
             </ul>
             </Col>
+            {
+            //if completed, display key patterns, otherwise display buttons
+            completed ?
+            <Col lg={{span: 6, offset: 0}} xl={{span: 5, offset: 1}}>
+                <h3 className="fs-4 text-success">Key Design Patterns</h3>
+                <ul>
+                    {details.keyPatterns.map((pattern, index) => {
+                        return <li key={index}>{pattern + (pattern[-1] !== "." && ".")}</li>
+                    })}
+                </ul>
+            </Col>
+            :
+            <Col>
+                <ButtonToolbar className="d-flex align-items-end justify-content-around">
+                    <Button className="m-1" target="_blank" href="/editor">Open Editor</Button>
+                    <Button className="m-1" href={"/solutions/post/" + id}>Post a Solution</Button>
+                    <Button className="m-1" target="_blank" href={"/solutions/challenge/" + id}>View Solutions</Button>
+                </ButtonToolbar>
+            </Col>
+            }            
         </Row>
-        <Row className="mt-4">
-            <ButtonToolbar className="d-flex justify-content-evenly">
+        {
+        // If completed, display buttons at the bottom
+        completed &&
+        <Row>
+           <ButtonToolbar className="d-flex align-items-end justify-content-around">
                 <Button className="m-1" target="_blank" href="/editor">Open Editor</Button>
                 <Button className="m-1" href={"/solutions/post/" + id}>Post a Solution</Button>
                 <Button className="m-1" target="_blank" href={"/solutions/challenge/" + id}>View Solutions</Button>
             </ButtonToolbar>
-        </Row>
+        </Row>}
         </ section>
     </Container>);
   };

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -2,17 +2,10 @@
 
 import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHeader, AccordionBody, Accordion } from "react-bootstrap";
 import { useEffect, useState } from "react";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
 import DifficultyBadge from "../components/DifficultyBadge";
 
-function useScrollToTop() {
-    const { pathname } = useLocation();
-
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [pathname]);
-}
 
 const Challenge = () => {
     //TODO: Fetch this value from the server
@@ -22,7 +15,6 @@ const Challenge = () => {
 
     const { id } = useParams();
 
-    useScrollToTop();
 
     useEffect(() => {   
         //fetch data about the challenge with the provided "id"

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -4,7 +4,7 @@ import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHea
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
-// import { getDifficulty } from "../utils";
+import { ChallengeDifficulties } from "../types/challengeDifficulties";
 import DifficultyBadge from "../components/DifficultyBadge";
 
 const Challenge = () => {

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -4,7 +4,6 @@ import { Container, Row, Col, ButtonToolbar, Button, AccordionItem, AccordionHea
 import { useEffect, useState } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { ChallengeDetails } from "../types/challengeDetails";
-import { ChallengeDifficulties } from "../types/challengeDifficulties";
 import DifficultyBadge from "../components/DifficultyBadge";
 
 function useScrollToTop() {
@@ -25,8 +24,6 @@ const Challenge = () => {
 
     useScrollToTop();
 
-    //TODO: Refactor once the API is ready
-    //TODO: Refactor once the API is ready
     useEffect(() => {   
         //fetch data about the challenge with the provided "id"
         fetch('/api/challenges/' + id).then((response) => {

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -1,50 +1,164 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ChallengeCard from "../components/ChallengeCard";
-import { ChallengeCardProps } from "../components/ChallengeCard";
-import { Container, Row, Col, Button, Stack } from "react-bootstrap";
+import { Container, Row, Col, Button, Stack, Dropdown, Form, FormCheck} from "react-bootstrap";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort";
-
-
+import { ChallengeDifficulties } from "../types/challengeDifficulties";
+// START FOR TESTING ONLY
+const challengesDemo: ChallengeDetailsShort[] = [
+    {
+        title: "Demo Challenge Card",
+        generalDescription:
+            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
+            " and getting review, we provide you all you need to become a Software Architecture monster!",
+        id: 0,
+        difficulty: ChallengeDifficulties.HARD,
+    },
+    {
+        title: "Demo Challenge Card",
+        generalDescription:
+            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
+            " and getting review, we provide you all you need to become a Software Architecture monster!",
+        id: 1,
+        difficulty: ChallengeDifficulties.MEDIUM,
+    },
+    {
+        title: "Demo Challenge Card",
+        generalDescription:
+            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
+            " and getting review, we provide you all you need to become a Software Architecture monster!",
+        id: 2,
+        difficulty: ChallengeDifficulties.EASY,
+    },
+    {
+        title: "Demo Challenge Card",
+        generalDescription:
+            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
+            " and getting review, we provide you all you need to become a Software Architecture monster!",
+        id: 3,
+        difficulty: ChallengeDifficulties.HARD,
+    },
+    {
+        title: "Demo Challenge Card",
+        generalDescription:
+            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
+            " and getting review, we provide you all you need to become a Software Architecture monster!",
+        id: 4,
+        difficulty: ChallengeDifficulties.MEDIUM,
+    }
+]
+// END FOR TESTING ONLY
 
 function Challenges() {
-    const [challengesData, setChallengesData] = useState([]);
-    // const [isLoading, setIsLoading] = useState(true); // Could be used to show a loading spinner
+    const [challengesData, setChallengesData] = useState([] as ChallengeDetailsShort[]);
+    const [sortByDifficulty, setSortByDifficulty] = useState(false);
+    const [filterByDifficulty, setFilterByDifficulty] = useState([] as ChallengeDifficulties[]);
+    const [hideComplete, setHideComplete] = useState(false);
 
-    // function makeGrid(challenges: ChallengeDetailsShort[]): JSX.Element[] {
-    //     let grid: JSX.Element[] = [];
-    //     let row: JSX.Element[] = [];
-    //     let i = 0;
-    //     for (const challenge of challenges) {
-    //         const cardProps: ChallengeCardProps = {
-    //             title: challenge.title,
-    //             difficulty: challenge.difficulty,
-    //             generalDescription: challenge.generalDescription,
-    //         };
-    //         row.push(
-    //             <Col key={i} className="mb-4">
-    //                 <ChallengeCard {...cardProps} />
-    //             </Col>
-    //         );
-    //         i++;
-    //         if (i % 3 === 0) {
-    //             grid.push(<Row key={i}>{row}</Row>);
-    //             row = [];
-    //         }
-    //     }
-    //     if (row.length > 0) {
-    //         grid.push(<Row key={i}>{row}</Row>);
-    //     }
-    //     return grid;
+    function makeGrid(challenges: ChallengeDetailsShort[]): JSX.Element[] {
+        const grid: JSX.Element[] = [];
+        let row: JSX.Element[] = [];
+        let i = 0;
+        for (const challenge of challenges) {
+            row.push(
+                <Col lg={4} key={i} className="mb-4">
+                    <ChallengeCard {...challenge} />
+                </Col>
+            );
+            i++;
+            if (i % 3 === 0) {
+                grid.push(<Row sm={1} lg={3} key={i}>{row}</Row>);
+                row = [];
+            }
+        }
+        if (row.length > 0) {
+            grid.push(<Row key={i}>{row}</Row>);
+        }
+        return grid;
+    }
+
+    useEffect(() => {    
+        //NEXT LINE IS FOR TESTING ONLY
+        setChallengesData(challengesDemo);
+    }, [hideComplete, sortByDifficulty, filterByDifficulty]);
+
+    const handleSortByDifficulty = () => {
+        setSortByDifficulty(!sortByDifficulty);
+        if (sortByDifficulty) {
+            // Sort challengesData in ascending order by difficulty
+            setChallengesData([...challengesData].sort((a, b) => a.difficulty - b.difficulty));
+        } else {
+            // Sort challengesData in descending order by difficulty
+            setChallengesData([...challengesData].sort((a, b) => b.difficulty - a.difficulty));
+        }
+    };
+
+    function handleFilterByDifficulty() {
+        return ;
     }
 
     return(
         <section>
             <Container>
-                {}
+                <Row className="my-2">
+                    <Col>
+                    <header>
+                        <h1 className="fs-2">Challenges</h1>
+                        <h2 className="fs-5">Choose a challenge to start solving!</h2>
+                        </header>
+                    </Col>
+                    <Col>
+                        <Dropdown className="mt-4 float-end "> 
+                            <Dropdown.Toggle variant="primary" id="dropdown-basic">
+                                Sort by Difficulty
+                            </Dropdown.Toggle>
+                            <Dropdown.Menu>
+                                <Dropdown.Item onClick={handleSortByDifficulty}>
+                                    {sortByDifficulty ? "Easier First" : "Harder First"}
+                                </Dropdown.Item>
+                            </Dropdown.Menu>
+                        </Dropdown>
+                        <Dropdown className="mt-4 mx-2 float-end">
+                            <Dropdown.Toggle variant="primary" id="dropdown-basic">
+                                Filter by
+                            </Dropdown.Toggle>
+                            <Dropdown.Menu>
+                                <Form className="ms-2">
+                                    <Form.Label>Difficulty</Form.Label>
+                                    <Form.Check
+                                        type="checkbox"
+                                        label="Easy"
+                                        onChange={handleFilterByDifficulty}
+                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.EASY)}
+                                    />
+                                    <Form.Check
+                                        type="checkbox"
+                                        label="Medium"
+                                        onChange={handleFilterByDifficulty}
+                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.MEDIUM)}
+                                    />
+                                    <Form.Check
+                                        type="checkbox"
+                                        label="Hard"
+                                        onChange={handleFilterByDifficulty}
+                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.HARD)}
+                                    />
+                                    </Form>
+                                </Dropdown.Menu>
+                            </Dropdown>
+                        <Button 
+                            className={"mt-4 float-end " + (hideComplete ? "btn-primary" : "btn-danger")}
+                            onClick={() => {setHideComplete(!hideComplete)}}
+                            >
+                            {hideComplete ? "Showing Completed" : "Hiding Completed"}
+                        </Button>        
+                    </Col>
+                </Row>
+                {makeGrid(challengesData)}
             </Container>
         </section>
     );
 }
+
 
 export default Challenges;

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -30,7 +30,6 @@ function Challenges() {
             setIsLoading(false);
             return;
         }).catch((err) => {
-            console.log();
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             console.error("Failed fetching the challenges." + "\nError message: " + err.message)
         });

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -14,22 +14,6 @@ function Challenges() {
     const [sortByDifficulty, setSortByDifficulty] = useState(false);
     const [filter, setFilter] = useState([] as ChallengeDifficulties[]);
     const [hideComplete, setHideComplete] = useState(false);
-
-
-    /**
-     * Handles the sorting of challenges by difficulty
-     */
-    const handleSortByDifficulty = useCallback((prevChallengesData: ChallengeDetailsShort[]) => {
-        const sortedChallengesData = [...prevChallengesData];
-        if (!sortByDifficulty) {
-            // Sort challengesData in ascending order by difficulty
-            sortedChallengesData.sort((a, b) => a.difficulty - b.difficulty);
-        } else {
-            // Sort challengesData in descending order by difficulty
-            sortedChallengesData.sort((a, b) => b.difficulty - a.difficulty);
-        }
-        return sortedChallengesData;
-    }, [sortByDifficulty]);
     
 
     useEffect(() => {   
@@ -54,6 +38,7 @@ function Challenges() {
 
    
     useEffect(() => {    
+    // Sort challengesData by difficulty
         if (challengesData != undefined) {
             const sortedChallengesData = handleSortByDifficulty(challengesData);
             setChallengesData(sortedChallengesData);
@@ -61,19 +46,13 @@ function Challenges() {
         console.log("Challenges sorted");
     }, [sortByDifficulty]);
 
-    
-    function handleFilter(difficulty: ChallengeDifficulties) {
-        if (filter.includes(difficulty)) {
-            setFilter(filter.filter((d) => d !== difficulty));
-        }
-        else {
-            setFilter([...filter, difficulty]);
-        }
-    }
 
-
-    function makeGrid() {
-        if (challengesData === undefined) {
+    /**
+     * Make a grid of ChallengeCards depending on the challengesData
+     * @returns a bootstrap grid of ChallengeCards
+     */
+    const makeGrid = useCallback((): JSX.Element[] => {
+        if (isLoading || challengesData === undefined) {
             return [];
         }
     
@@ -109,6 +88,29 @@ function Challenges() {
         }
         console.log("Grid made");
         return grid;
+    }, [isLoading, challengesData, filter, hideComplete]);
+    
+
+    function handleSortByDifficulty (prevChallengesData: ChallengeDetailsShort[]) {
+        const sortedChallengesData = [...prevChallengesData];
+        if (!sortByDifficulty) {
+            // Sort challengesData in ascending order by difficulty
+            sortedChallengesData.sort((a, b) => a.difficulty - b.difficulty);
+        } else {
+            // Sort challengesData in descending order by difficulty
+            sortedChallengesData.sort((a, b) => b.difficulty - a.difficulty);
+        }
+        return sortedChallengesData;
+    }
+
+
+    function handleFilter(difficulty: ChallengeDifficulties) {
+        if (filter.includes(difficulty)) {
+            setFilter(filter.filter((d) => d !== difficulty));
+        }
+        else {
+            setFilter([...filter, difficulty]);
+        }
     }
     
 
@@ -147,7 +149,6 @@ function Challenges() {
                                             onClick={() => {
                                                 handleFilter(ChallengeDifficulties.EASY);
                                             }}
-                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.EASY)}
                                         />
                                         <Form.Check
                                             type="checkbox"
@@ -156,7 +157,6 @@ function Challenges() {
                                                 () => {
                                                     handleFilter(ChallengeDifficulties.MEDIUM);
                                                 }}
-                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.MEDIUM)}
                                         />
                                         <Form.Check
                                             type="checkbox"
@@ -165,7 +165,6 @@ function Challenges() {
                                                 () => {
                                                     handleFilter(ChallengeDifficulties.HARD);
                                                 }}
-                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.HARD)}
                                         />
                                         </Form>
                                     </Dropdown.Menu>

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -4,55 +4,14 @@ import ChallengeCard from "../components/ChallengeCard";
 import { Container, Row, Col, Button, Stack, Dropdown, Form, FormCheck} from "react-bootstrap";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort";
 import { ChallengeDifficulties } from "../types/challengeDifficulties";
-// START FOR TESTING ONLY
-const challengesDemo: ChallengeDetailsShort[] = [
-    {
-        title: "Demo Challenge Card",
-        generalDescription:
-            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
-            " and getting review, we provide you all you need to become a Software Architecture monster!",
-        id: 0,
-        difficulty: ChallengeDifficulties.HARD,
-    },
-    {
-        title: "Demo Challenge Card",
-        generalDescription:
-            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
-            " and getting review, we provide you all you need to become a Software Architecture monster!",
-        id: 1,
-        difficulty: ChallengeDifficulties.MEDIUM,
-    },
-    {
-        title: "Demo Challenge Card",
-        generalDescription:
-            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
-            " and getting review, we provide you all you need to become a Software Architecture monster!",
-        id: 2,
-        difficulty: ChallengeDifficulties.EASY,
-    },
-    {
-        title: "Demo Challenge Card",
-        generalDescription:
-            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
-            " and getting review, we provide you all you need to become a Software Architecture monster!",
-        id: 3,
-        difficulty: ChallengeDifficulties.HARD,
-    },
-    {
-        title: "Demo Challenge Card",
-        generalDescription:
-            "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
-            " and getting review, we provide you all you need to become a Software Architecture monster!",
-        id: 4,
-        difficulty: ChallengeDifficulties.MEDIUM,
-    }
-]
-// END FOR TESTING ONLY
+
 
 function Challenges() {
-    const challengesData = useRef(challengesDemo);
+    const challengesData = useRef<ChallengeDetailsShort[]>();
 
     const [grid, setGrid] = useState([] as JSX.Element[]);
+    const [isLoading, setIsLoading] = useState(true);
+
     const [sortByDifficulty, setSortByDifficulty] = useState(false);
     const [filter, setFilter] = useState(0);
     const [hideComplete, setHideComplete] = useState(false);
@@ -72,7 +31,6 @@ function Challenges() {
         }
         return sortedChallengesData;
     }, [sortByDifficulty]);
-
     
 
     /**
@@ -81,6 +39,10 @@ function Challenges() {
      * @returns the grid of ChallengeCards
      */
     const makeGrid = useCallback((): JSX.Element[] => {
+        if (challengesData.current === undefined) {
+            return [];
+        }
+
         const grid: JSX.Element[] = [];
         let row: JSX.Element[] = [];
         let i = 0;
@@ -108,13 +70,35 @@ function Challenges() {
         return grid;
     }, [filter]);
 
+    useEffect(() => {   
+        //fetch data about the challenge with the provided "id"
+        setIsLoading(true);
+        fetch('/api/challenges').then((response) => {
+            if(!response.ok){
+                throw new Error(response.statusText);                
+            }
+            return response.json() as Promise<ChallengeDetailsShort[]>; //THIS LINE MAY CAUSE ERRORS. Need to test with proper server.
+        }).then((data) => {
+            challengesData.current = data;
+            console.log(data);
+            setIsLoading(false);
+            return;
+        }).catch((err) => {
+            console.log();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            console.error("Failed fetching the challenges." + "\nError message: " + err.message)
+        });
+   }, [challengesData]);
 
     useEffect(() => {    
-        const sortedChallengesData = handleSortByDifficulty(challengesData.current);
-        challengesData.current = sortedChallengesData;
+        if (challengesData.current != undefined) {
+            const sortedChallengesData = handleSortByDifficulty(challengesData.current);
+            challengesData.current = sortedChallengesData;
+        }
         const newGrid = makeGrid();
         setGrid(newGrid);
-    }, [hideComplete, challengesData, makeGrid, handleSortByDifficulty]);
+        console.log("Grid updated");
+    }, [hideComplete, makeGrid, handleSortByDifficulty, challengesData, isLoading]);
 
     
     /**

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ChallengeCard from "../components/ChallengeCard";
-import { Container, Row, Col, Button, Stack, Dropdown, Form, FormCheck} from "react-bootstrap";
+import { Container, Row, Col, Button, Spinner, Dropdown, Form, FormCheck} from "react-bootstrap";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort";
 import { ChallengeDifficulties } from "../types/challengeDifficulties";
 
@@ -53,7 +53,13 @@ function Challenges() {
      */
     const makeGrid = useCallback((): JSX.Element[] => {
         if (isLoading || challengesData === undefined) {
-            return [];
+            return ([
+            <Row key="spinner" className="d-flex justify-content-center">
+                <Spinner animation="border" role="status">
+                    <span className="visually-hidden">Loading...</span>
+                </Spinner>
+            </Row>
+            ])
         }
     
         const grid: JSX.Element[] = [];
@@ -112,7 +118,7 @@ function Challenges() {
             setFilter([...filter, difficulty]);
         }
     }
-    
+
 
     return(
         <section>

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -138,70 +138,71 @@ function Challenges() {
     return(
         <section>
             <Container>
-                <Row className="my-2">
-                    <Col>
-                    <header>
-                        <h1 className="fs-2">Challenges</h1>
-                        <h2 className="fs-5">Choose a challenge to start solving!</h2>
-                        </header>
-                    </Col>
-                    <Col>
-                        <Dropdown className="mt-4 float-end "> 
-                            <Dropdown.Toggle variant="primary" id="dropdown-basic">
-                                Sort by Difficulty
-                            </Dropdown.Toggle>
-                            <Dropdown.Menu>
-                                <Dropdown.Item onClick={ () => {
-                                    setSortByDifficulty(!sortByDifficulty);
-                                }}>
-                                    {sortByDifficulty ? "Easier First" : "Harder First"}
-                                </Dropdown.Item>
-                            </Dropdown.Menu>
-                        </Dropdown>
-                        <Dropdown className="mt-4 mx-2 float-end">
-                            <Dropdown.Toggle variant="primary" id="dropdown-basic">
-                                Filter by
-                            </Dropdown.Toggle>
-                            <Dropdown.Menu>
-                                <Form className="ms-2">
-                                    <Form.Label>Difficulty</Form.Label>
-                                    <Form.Check
-                                        type="checkbox"
-                                        label="Easy"
-                                        onClick={() => {
-                                            filterIncluded(ChallengeDifficulties.EASY, filter) ? setFilter(filter & 6) : setFilter(filter | 1);
-                                        }}
-                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.EASY)}
-                                    />
-                                    <Form.Check
-                                        type="checkbox"
-                                        label="Medium"
-                                        onClick={
-                                            () => {
-                                                filterIncluded(ChallengeDifficulties.MEDIUM, filter) ? setFilter(filter & 5) : setFilter(filter | 2);
-                                        }}
-                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.MEDIUM)}
-                                    />
-                                    <Form.Check
-                                        type="checkbox"
-                                        label="Hard"
-                                        onClick={
-                                            () => {
-                                                filterIncluded(ChallengeDifficulties.HARD, filter) ? setFilter(filter & 3) : setFilter(filter | 4);
-                                        }}
-                                        // checked={filterByDifficulty.includes(ChallengeDifficulties.HARD)}
-                                    />
-                                    </Form>
+                <header>
+                    <Row className="my-2">
+                        <Col>
+                            <h1 className="fs-2">Challenges</h1>
+                            <h2 className="fs-5">Choose a challenge to start solving!</h2>
+                        </Col>
+                        <Col>
+                            <Dropdown className="mt-4 float-end "> 
+                                <Dropdown.Toggle variant="primary" id="dropdown-basic">
+                                    Sort by Difficulty
+                                </Dropdown.Toggle>
+                                <Dropdown.Menu>
+                                    <Dropdown.Item onClick={ () => {
+                                        setSortByDifficulty(!sortByDifficulty);
+                                    }}>
+                                        {sortByDifficulty ? "Easier First" : "Harder First"}
+                                    </Dropdown.Item>
                                 </Dropdown.Menu>
                             </Dropdown>
-                        <Button 
-                            className={"mt-4 float-end " + (hideComplete ? "btn-primary" : "btn-danger")}
-                            onClick={() => {setHideComplete(!hideComplete)}}
-                            >
-                            {hideComplete ? "Showing Completed" : "Hiding Completed"}
-                        </Button>        
-                    </Col>
-                </Row>
+                            <Dropdown className="mt-4 mx-2 float-end">
+                                <Dropdown.Toggle variant="primary" id="dropdown-basic">
+                                    Filter by
+                                </Dropdown.Toggle>
+                                <Dropdown.Menu>
+                                    <Form className="ms-2">
+                                        <Form.Label>Difficulty</Form.Label>
+                                        <Form.Check
+                                            type="checkbox"
+                                            label="Easy"
+                                            onClick={() => {
+                                                filterIncluded(ChallengeDifficulties.EASY, filter) ? setFilter(filter & 6) : setFilter(filter | 1);
+                                            }}
+                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.EASY)}
+                                        />
+                                        <Form.Check
+                                            type="checkbox"
+                                            label="Medium"
+                                            onClick={
+                                                () => {
+                                                    filterIncluded(ChallengeDifficulties.MEDIUM, filter) ? setFilter(filter & 5) : setFilter(filter | 2);
+                                            }}
+                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.MEDIUM)}
+                                        />
+                                        <Form.Check
+                                            type="checkbox"
+                                            label="Hard"
+                                            onClick={
+                                                () => {
+                                                    filterIncluded(ChallengeDifficulties.HARD, filter) ? setFilter(filter & 3) : setFilter(filter | 4);
+                                            }}
+                                            // checked={filterByDifficulty.includes(ChallengeDifficulties.HARD)}
+                                        />
+                                        </Form>
+                                    </Dropdown.Menu>
+                                </Dropdown>
+                            <Button 
+                                className={"mt-4 float-end " + (hideComplete ? "btn-primary" : "btn-danger")}
+                                onClick={() => {setHideComplete(!hideComplete)}}
+                                >
+                                {hideComplete ? "Showing Completed" : "Hiding Completed"}
+                            </Button>        
+                        </Col>
+                    </Row>
+                </header>
+
                 {grid}
             </Container>
         </section>

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ChallengeCard from "../components/ChallengeCard";
 import { Container, Row, Col, Button, Stack, Dropdown, Form, FormCheck} from "react-bootstrap";
 import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort";
@@ -50,9 +50,9 @@ const challengesDemo: ChallengeDetailsShort[] = [
 // END FOR TESTING ONLY
 
 function Challenges() {
+    const challengesData = useRef(challengesDemo);
 
     const [grid, setGrid] = useState([] as JSX.Element[]);
-    const [challengesData, setChallengesData] = useState(challengesDemo);
     const [sortByDifficulty, setSortByDifficulty] = useState(false);
     const [filter, setFilter] = useState(0);
     const [hideComplete, setHideComplete] = useState(false);
@@ -61,9 +61,9 @@ function Challenges() {
     /**
      * Handles the sorting of challenges by difficulty
      */
-    function handleSortByDifficulty(prevChallengesData: ChallengeDetailsShort[]) {
+    const handleSortByDifficulty = useCallback((prevChallengesData: ChallengeDetailsShort[]) => {
         const sortedChallengesData = [...prevChallengesData];
-        if (sortByDifficulty) {
+        if (!sortByDifficulty) {
             // Sort challengesData in ascending order by difficulty
             sortedChallengesData.sort((a, b) => a.difficulty - b.difficulty);
         } else {
@@ -71,7 +71,7 @@ function Challenges() {
             sortedChallengesData.sort((a, b) => b.difficulty - a.difficulty);
         }
         return sortedChallengesData;
-    }
+    }, [sortByDifficulty]);
 
     
 
@@ -84,7 +84,7 @@ function Challenges() {
         const grid: JSX.Element[] = [];
         let row: JSX.Element[] = [];
         let i = 0;
-        for (const challenge of challengesData) {
+        for (const challenge of challengesData.current) {
             //make sure the challenge is not filtered out
             if(!(filterIncluded(challenge.difficulty, filter) || filter === 0)) {
                 // console.log("Filtering out: " + challenge.difficulty);
@@ -106,18 +106,17 @@ function Challenges() {
             grid.push(<Row key={i}>{row}</Row>);
         }
         return grid;
-    }, [filter, challengesData]);
+    }, [filter]);
 
 
     useEffect(() => {    
-        //NEXT LINE IS FOR TESTING ONLY
-        // setChallengesData(challengesDemo);
-        // const sortedChallengesData = useMemo(()=> {return handleSortByDifficulty(challengesData)}, sortByDifficulty);
-        // setChallengesData(sortedChallengesData);
+        const sortedChallengesData = handleSortByDifficulty(challengesData.current);
+        challengesData.current = sortedChallengesData;
         const newGrid = makeGrid();
         setGrid(newGrid);
-    }, [hideComplete, challengesData, makeGrid]);
+    }, [hideComplete, challengesData, makeGrid, handleSortByDifficulty]);
 
+    
     /**
      * Retuns true if the difficulty is included in the filter
      */

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useState } from "react";
+import ChallengeCard from "../components/ChallengeCard";
+import { ChallengeCardProps } from "../components/ChallengeCard";
+import { Container, Row, Col, Button, Stack } from "react-bootstrap";
+import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort";
+
+
+
+function Challenges() {
+    const [challengesData, setChallengesData] = useState([]);
+    // const [isLoading, setIsLoading] = useState(true); // Could be used to show a loading spinner
+
+    // function makeGrid(challenges: ChallengeDetailsShort[]): JSX.Element[] {
+    //     let grid: JSX.Element[] = [];
+    //     let row: JSX.Element[] = [];
+    //     let i = 0;
+    //     for (const challenge of challenges) {
+    //         const cardProps: ChallengeCardProps = {
+    //             title: challenge.title,
+    //             difficulty: challenge.difficulty,
+    //             generalDescription: challenge.generalDescription,
+    //         };
+    //         row.push(
+    //             <Col key={i} className="mb-4">
+    //                 <ChallengeCard {...cardProps} />
+    //             </Col>
+    //         );
+    //         i++;
+    //         if (i % 3 === 0) {
+    //             grid.push(<Row key={i}>{row}</Row>);
+    //             row = [];
+    //         }
+    //     }
+    //     if (row.length > 0) {
+    //         grid.push(<Row key={i}>{row}</Row>);
+    //     }
+    //     return grid;
+    }
+
+    return(
+        <section>
+            <Container>
+                {}
+            </Container>
+        </section>
+    );
+}
+
+export default Challenges;

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -77,7 +77,7 @@ function Challenges() {
             if(!response.ok){
                 throw new Error(response.statusText);                
             }
-            return response.json() as Promise<ChallengeDetailsShort[]>; //THIS LINE MAY CAUSE ERRORS. Need to test with proper server.
+            return response.json() as Promise<ChallengeDetailsShort[]>;
         }).then((data) => {
             challengesData.current = data;
             console.log(data);

--- a/client/src/pages/Challenges.tsx
+++ b/client/src/pages/Challenges.tsx
@@ -13,7 +13,7 @@ function Challenges() {
     const [isLoading, setIsLoading] = useState(true);
 
     const [sortByDifficulty, setSortByDifficulty] = useState(false);
-    const [filter, setFilter] = useState(0);
+    const [filter, setFilter] = useState([] as ChallengeDifficulties[]);
     const [hideComplete, setHideComplete] = useState(false);
 
 
@@ -48,10 +48,16 @@ function Challenges() {
         let i = 0;
         for (const challenge of challengesData.current) {
             //make sure the challenge is not filtered out
-            if(!(filterIncluded(challenge.difficulty, filter) || filter === 0)) {
+            if(!(filter.includes(challenge.difficulty)) && filter.length > 0) {
                 // console.log("Filtering out: " + challenge.difficulty);
+                // console.log(filter);
                 continue;
             }
+            
+            // if(hideComplete && challenge.completed) { //TODO: add completed field to challengeDetailsShort
+            //     // console.log("Filtering out: " + challenge.title);
+            //     continue;
+            // }
 
             row.push(
                 <Col lg={4} key={i} className="mb-4">
@@ -69,6 +75,7 @@ function Challenges() {
         }
         return grid;
     }, [filter]);
+
 
     useEffect(() => {   
         //fetch data about the challenge with the provided "id"
@@ -88,8 +95,9 @@ function Challenges() {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             console.error("Failed fetching the challenges." + "\nError message: " + err.message)
         });
-   }, [challengesData]);
+   }, []);
 
+   
     useEffect(() => {    
         if (challengesData.current != undefined) {
             const sortedChallengesData = handleSortByDifficulty(challengesData.current);
@@ -98,23 +106,15 @@ function Challenges() {
         const newGrid = makeGrid();
         setGrid(newGrid);
         console.log("Grid updated");
-    }, [hideComplete, makeGrid, handleSortByDifficulty, challengesData, isLoading]);
+    }, [hideComplete, makeGrid, handleSortByDifficulty, challengesData, filter, isLoading]);
 
     
-    /**
-     * Retuns true if the difficulty is included in the filter
-     */
-    function filterIncluded(difficulty: ChallengeDifficulties, filter: number): boolean {
-        console.log("Filter: " + filter);
-        switch(difficulty) {
-            case ChallengeDifficulties.EASY:
-                return (filter & 1) === 1;
-            case ChallengeDifficulties.MEDIUM:
-                return (filter & 2) === 2;
-            case ChallengeDifficulties.HARD:
-                return (filter & 4) === 4;
-            default:
-                return false;
+    function handleFilter(difficulty: ChallengeDifficulties) {
+        if (filter.includes(difficulty)) {
+            setFilter(filter.filter((d) => d !== difficulty));
+        }
+        else {
+            setFilter([...filter, difficulty]);
         }
     }
 
@@ -152,7 +152,7 @@ function Challenges() {
                                             type="checkbox"
                                             label="Easy"
                                             onClick={() => {
-                                                filterIncluded(ChallengeDifficulties.EASY, filter) ? setFilter(filter & 6) : setFilter(filter | 1);
+                                                handleFilter(ChallengeDifficulties.EASY);
                                             }}
                                             // checked={filterByDifficulty.includes(ChallengeDifficulties.EASY)}
                                         />
@@ -161,8 +161,8 @@ function Challenges() {
                                             label="Medium"
                                             onClick={
                                                 () => {
-                                                    filterIncluded(ChallengeDifficulties.MEDIUM, filter) ? setFilter(filter & 5) : setFilter(filter | 2);
-                                            }}
+                                                    handleFilter(ChallengeDifficulties.MEDIUM);
+                                                }}
                                             // checked={filterByDifficulty.includes(ChallengeDifficulties.MEDIUM)}
                                         />
                                         <Form.Check
@@ -170,8 +170,8 @@ function Challenges() {
                                             label="Hard"
                                             onClick={
                                                 () => {
-                                                    filterIncluded(ChallengeDifficulties.HARD, filter) ? setFilter(filter & 3) : setFilter(filter | 4);
-                                            }}
+                                                    handleFilter(ChallengeDifficulties.HARD);
+                                                }}
                                             // checked={filterByDifficulty.includes(ChallengeDifficulties.HARD)}
                                         />
                                         </Form>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -4,9 +4,9 @@ import SolutionCard, {
   SolutionCardProps,
 } from "../components/SolutionCard.tsx";
 import { ArrowUpRightSquare } from "react-bootstrap-icons";
-import ChallengeCard, {
-  ChallengeCardProps,
-} from "../components/ChallengeCard.tsx";
+import ChallengeCard from "../components/ChallengeCard.tsx";
+import { ChallengeDifficulties } from "../types/challengeDifficulties.ts";
+import { ChallengeDetailsShort } from "../types/ChallengeDetailsShort.ts";
 
 const DEMO_SOLUTION_CARDS: SolutionCardProps[] = Array(5).fill({
   title: "Example Challenge 1: Airport Management System",
@@ -14,16 +14,16 @@ const DEMO_SOLUTION_CARDS: SolutionCardProps[] = Array(5).fill({
     "Some quick example text to build on the card title and make up the bulk of the card's content.",
   imgSrc:
     "https://images.unsplash.com/photo-1596496181871-9681eacf9764?q=80&w=2086&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  href: "/home",
-  difficulty: "medium",
+  href: "/home"
 });
 
-const DEMO_CHALLENGE_CARDS: ChallengeCardProps[] = Array(3).fill({
+const DEMO_CHALLENGE_CARDS: ChallengeDetailsShort[] = Array(3).fill({
   title: "Demo Challenge Card",
-  description:
+  generalDescription:
     "In this demo challenge you will be demoing our platform. From creating UML diagrams to submitting" +
     " and getting review, we provide you all you need to become a Software Architecture monster!",
-  href: "/home",
+  id: 0,
+  difficulty: ChallengeDifficulties.MEDIUM,
 });
 
 function Home() {
@@ -59,7 +59,7 @@ function Home() {
         </Stack>
         <Row sm={1} lg={3} className={"gx-4 gy-4"}>
           {DEMO_CHALLENGE_CARDS.map((challengeCardProps) => (
-            <Col key={challengeCardProps.href}>
+            <Col key={challengeCardProps.id}>
               <ChallengeCard {...challengeCardProps} />
             </Col>
           ))}

--- a/client/src/types/ChallengeDetailsShort.ts
+++ b/client/src/types/ChallengeDetailsShort.ts
@@ -4,5 +4,5 @@ export type ChallengeDetailsShort = {
     title: string;
     difficulty: ChallengeDifficulties;
     generalDescription: string;
-    id: string;
+    id: number;
 }

--- a/client/src/types/ChallengeDetailsShort.ts
+++ b/client/src/types/ChallengeDetailsShort.ts
@@ -1,0 +1,8 @@
+import { ChallengeDifficulties } from './challengeDifficulties';
+
+export type ChallengeDetailsShort = {
+    title: string;
+    difficulty: ChallengeDifficulties;
+    generalDescription: string;
+    id: string;
+}

--- a/server/controllers/ChallengeController.js
+++ b/server/controllers/ChallengeController.js
@@ -12,7 +12,6 @@ function diffToNum(difficulty) {
         default:
             return -1;
     }
-
 }
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -11,11 +11,11 @@ const PORT = process.env.PORT || 8080;
 
 
 // Sync Sequelize models 
-db.sequelize.sync({ force: true, logging: false}).then(async () => { // Use { force: true } cautiously as it will drop existing tables
+db.sequelize.sync().then(async () => { // Use { force: true } cautiously as it will drop existing tables
     console.log('Database synced');
 
-    //import the challenges into the db
-    await importChallenges();
+    // import the challenges into the db. Comment out after first run
+    // await importChallenges();
 
     // Start listening for requests after the database is ready
     app.listen(PORT, () => {

--- a/server/routes/ChallengeRoutes.js
+++ b/server/routes/ChallengeRoutes.js
@@ -13,12 +13,12 @@ router.get("/:id", Challenge.findOne);
 // router.get("/:id", Challenge.getSolutions);
 
 // Create a new challenge in the database.
-router.post("/:id", Challenge.create);
+// router.post("/:id", Challenge.create);
 
 // Edit a challenge in the database.
-router.put("/:id", Challenge.edit);
+// router.put("/:id", Challenge.edit);
 
 // Delete a challenge from the database.
-router.delete("/:id", Challenge.delete);
+// router.delete("/:id", Challenge.delete);
 
 module.exports = router;

--- a/server/scripts/importChallenges.js
+++ b/server/scripts/importChallenges.js
@@ -3,7 +3,6 @@ const Challenge = db.Challenge;
 const challenges = require("../../challenges.json"); // Import the challenges data
 
 
-
 // Sync the challenges data with the database
 
 module.exports = async function importChallenges(dropTable = false) {

--- a/server/scripts/importChallenges.js
+++ b/server/scripts/importChallenges.js
@@ -2,10 +2,15 @@ const db = require("../models/index");
 const Challenge = db.Challenge;
 const challenges = require("../../challenges.json"); // Import the challenges data
 
+
+
 // Sync the challenges data with the database
 
-module.exports = async function importChallenges() {
-    
+module.exports = async function importChallenges(dropTable = false) {
+    // Drop the existing Challenge table
+    if (dropTable)
+    await Challenge.drop();
+
     // Break down by difficulty
     const easyChallenges = challenges.challenges.easy;
     const mediumChallenges = challenges.challenges.medium;
@@ -28,9 +33,8 @@ module.exports = async function importChallenges() {
             };
 
             await Challenge.create(newEasyChallenge);
-            });
-        }
-    catch (error) {
+        });
+    } catch (error) {
         console.error("Error importing easy challenges: " + error);
     }
     try {


### PR DESCRIPTION
close #5 

### Summary
Implemented the Challenges page displaying the `ChallengeCard`s of all existing challenges and allowing the user to sort/filer challenges.

### Future Todo
- [x] Redesign the Challenge details page for consistency.
- [ ] Add loading spinner for Challenge page.
- [ ] Incorporate `completed` challenge status into `ChallengeCard`s. (note that this will require authentication to work properly, but the client side can be tested by returning mock data from the server).

### Screenshots
#### Challenges list page
![image](https://github.com/utmgdsc/UML_Mentor/assets/121591697/8bb61dfd-029e-4436-9e06-2997354a9f3f)


#### Challenge page redesign
![image](https://github.com/utmgdsc/UML_Mentor/assets/121591697/df873789-874e-44bb-8612-851a8c4939ae)
![image](https://github.com/utmgdsc/UML_Mentor/assets/121591697/b116db25-f4f9-49ab-908b-334736f5f6fd)
![image](https://github.com/utmgdsc/UML_Mentor/assets/121591697/c89343f5-ae31-414a-b776-c1e6d0ff66f7)



