### PR TITLE
Editor page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,7 @@
         "react-bootstrap": "^2.10.0",
         "react-bootstrap-icons": "^1.10.3",
         "react-dom": "^18.2.0",
-        "react-drawio": "^0.1.2",
+        "react-drawio": "^0.1.7",
         "react-router-dom": "^6.21.3"
       },
       "devDependencies": {
@@ -4162,9 +4162,9 @@
       }
     },
     "node_modules/react-drawio": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/react-drawio/-/react-drawio-0.1.2.tgz",
-      "integrity": "sha512-I913iJYp/+eIaTWWBHCyQDEJnbWk31z/S9JVw0XtAh6XU8pJqktedTox2o+KsV+M+9+2EX4ZdWublzDkV7j61A==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/react-drawio/-/react-drawio-0.1.7.tgz",
+      "integrity": "sha512-qj1wRwaFuE+MU7lF2UE+Tf+j5Rw1JfexI9Kvc1bPU6GX/Gxl50IzdpHLVDJdRkDH35qiHaM5cIe1tVOttaxwkw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "react-bootstrap": "^2.10.0",
     "react-bootstrap-icons": "^1.10.3",
     "react-dom": "^18.2.0",
-    "react-drawio": "^0.1.2",
+    "react-drawio": "^0.1.7",
     "react-router-dom": "^6.21.3"
   },
   "devDependencies": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Solutions from "./pages/Solutions.tsx";
 import PostSolution from "./pages/PostSolution.tsx";
 import Solution from "./pages/Solution.tsx";
 import Profile from "./pages/Profile.tsx"
+import Editor from "./pages/Editor.tsx";
 
 const NAV_CONFIG = {
   brand: "UML Mentor",
@@ -66,6 +67,10 @@ const router = createBrowserRouter([
       {
         path: "/solutions/post/:id",
         element: <PostSolution />,
+      },
+      {
+        path: "editor",
+        element: <Editor />
       },
     ],
   },

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -9,8 +9,9 @@ import InstructionsPopup from '../components/InstructionsPopup';
 
 
 const Challenge = () => {
-    //TODO: Fetch this value from the server
-    const [completed, setCompleted] = useState(false); //TODO: This value should be fetched from the server
+    //TODO: Fetch this value from the server. 
+    // We can query the db for solutions with the current user id and the challenge id
+    const [completed, setCompleted] = useState(false);
     const [details, setDetails] = useState<ChallengeDetails>();
     const [isLoading, setIsLoading] = useState(true);
     const { id } = useParams();

--- a/client/src/pages/Challenge.tsx
+++ b/client/src/pages/Challenge.tsx
@@ -54,7 +54,7 @@ const Challenge = () => {
             return response.json() as Promise<ChallengeDetails>;
         }).then((data) => {
             setDetails(data);
-            setCompleted(true); //TODO: This value should be fetched from the server
+            setCompleted(false); //TODO: This value should be fetched from the server
             setIsLoading(false);
             // console.log(details);
             return;
@@ -112,7 +112,7 @@ const Challenge = () => {
             </ul>
           </Col>
         </Row>
-        <Row className={!completed ? "align-items-end" : ""}>
+        <Row className={!completed ? "align-items-end mb-4" : ""}>
           <Col lg={{ span: 6, offset: 0 }} xl={{ span: 5, offset: 1 }}>
             <h3 className="fs-4">Usage Scenarios</h3>
             <ul>
@@ -128,7 +128,7 @@ const Challenge = () => {
           {
             //if completed, display key patterns, otherwise display buttons
             completed ? (
-              <Col lg={{ span: 6, offset: 0 }} xl={{ span: 5, offset: 1 }}>
+              <Col lg={{ span: 6, offset: 0 }} xl={{ span: 5 }}>
                 <h3 className="fs-4 text-success">Key Design Patterns</h3>
                 <ul>
                   {details.keyPatterns.map((pattern, index) => {
@@ -141,9 +141,9 @@ const Challenge = () => {
                 </ul>
               </Col>
             ) : (
-              <Col>
-                <ButtonToolbar className="d-flex align-items-end justify-content-around">
-                  <Button className="m-1" target="_blank" href="/editor">
+              <Col lg={{ span: 6, offset: 0 }} xl={{ span: 5 }}>
+                <ButtonToolbar className="d-flex align-items-end justify-content-between">
+                  <Button className="m-1" target="_blank" href={"/editor?type=challenge&id=" + id}>
                     Open Editor
                   </Button>
                   <Button className="m-1" href={"/solutions/post/" + id}>
@@ -165,8 +165,8 @@ const Challenge = () => {
           // If completed, display buttons at the bottom
           completed && (
             <Row>
-              <ButtonToolbar className="d-flex align-items-end justify-content-around">
-                <Button className="m-1" target="_blank" href="/editor">
+              <ButtonToolbar className="d-flex align-items-end justify-content-around my-4">
+                <Button className="m-1" target="_blank" href={"/editor?type=challenge&id=" + id}>
                   Open Editor
                 </Button>
                 <Button className="m-1" href={"/solutions/post/" + id}>

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -18,7 +18,7 @@ const Editor = () => {
 
     const drawioRef = useRef<DrawIoEmbedRef>(null);
     const diagramData = useRef<string | undefined>(undefined);
-    //TODO: Allow the user to change the diagram name
+    //TODO: Allow the user to change the diagram name (super low proirity)
     const [diagramName, setDiagramName] = useState<string | null>(null);
     const diagramNameRef = useRef<string | null>(null); //Crutch for the handleSave function
     const diagramId = useRef<string | null>(null);

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -176,6 +176,7 @@ const Editor = () => {
                 < DrawIoEmbed 
                     ref={drawioRef}
                     configuration={CONFIG}
+                    exportFormat="xmlpng"
                     urlParameters={
                         {
                             // ui: "atlas",

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -5,13 +5,11 @@ import { useLocation } from 'react-router-dom';
 
 
 const CONFIG = {
-    defaultEdgeStyle: {endSize: 12, startSize: 12},
-    // autosaveDelay: 10000, // 10 seconds
+    defaultEdgeStyle: {endSize: 12, startSize: 12, edgeStyle: "orthogonalEdgeStyle", rounded: 1, curved:0},
     enableCustomLibraries: false,
     appendCustomLibraries: false,
     expandLibraries: true, 
     defaultLibraries: "uml",
-    //TODO: make the lines orthogonal and sharp
     override: false
 }   
 
@@ -40,13 +38,13 @@ const Editor = () => {
     const query = useQuery();
 
 
-    //autosave (export) the diagram every 10 seconds (ONLY FOR DIAGRAMS IN PROGRESS, NOT EDITING EXISTING SOLUTIONS)
+    //autosave (export) the diagram every 20 seconds (ONLY FOR DIAGRAMS IN PROGRESS, NOT EDITING EXISTING SOLUTIONS)
     useEffect(() => {
         if (query.get("type") !== "challenge") return;
         const interval = setInterval(() => {
             // console.log("autosaving");
             doExport();
-        }, 10000);
+        }, 20000);
         return () => { clearInterval(interval) };
     }, [query]);
 

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -17,7 +17,7 @@ const CONFIG = {
 const Editor = () => {
 
     const drawioRef = useRef<DrawIoEmbedRef>(null);
-    const diagramData = useRef<string | undefined>("");
+    const diagramData = useRef<string | undefined>(undefined);
     //TODO: Allow the user to change the diagram name
     const [diagramName, setDiagramName] = useState<string | null>(null);
     const diagramNameRef = useRef<string | null>(null); //Crutch for the handleSave function
@@ -78,9 +78,9 @@ const Editor = () => {
                 // console.log("Loaded diagram: " + diagramData.current + " with id: " + diagramId.current + " and name: " + diagramNameRef.current);
             })
             .catch((error: Error) => {
+                console.log("Error: " + error.message);
                 //if the solution in progress has not been created yet, create a new entry in the database
                 if(error.message === "No diagram found for this challenge") {
-
                     //fetch the challenge details from the server to get the title
                     fetch("/api/challenges/" + challengeId).then(response => { //GET
                         if (!response.ok) {
@@ -90,9 +90,8 @@ const Editor = () => {
                     }).then(data => {
                         setDiagramName(data.title + " Diagram");
                         diagramNameRef.current = data.title + " Diagram"; //Crutch for the handleSave function
-
                         //create a new diagram and save it to the server
-                        fetch("/api/inprogress" , { //POST
+                        return fetch("/api/inprogress" , { //POST
                             method: "POST",
                             headers: {
                                 "Content-Type": "application/json"
@@ -101,22 +100,18 @@ const Editor = () => {
                                 title: diagramNameRef.current, 
                                 challengeId: challengeId, 
                                 xml: ""})
-                        }).then(response => {
-                            if (!response.ok) {
-                                throw new Error(response.statusText);
-                            }
-                            return response.json() as Promise<{id: string, title: string}>
-                        }).then(data => {
-                            // console.log("Created new diagram with id: " + data.id + " and title: " + data.title);
-                            diagramId.current = data.id;
-                        })
-                        .catch((error) => {
-                            console.error(error);
                         });
+                    }).then(response => {
+                        if (!response.ok) {
+                            throw new Error(response.statusText);
+                        }
+                        return response.json() as Promise<{id: string}>
+                    }).then(data => {
+                        // console.log("Created new diagram with id: " + data.id + " and title: " + data.title);
+                        diagramId.current = data.id;
                     }).catch((error) => {
                         console.error(error);
                     });
-                    
                 } else {
                     //otherwise, log the error
                     console.error(error);

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
+import { Button } from 'react-bootstrap';
+import { ActionExport, DrawIoEmbed, DrawIoEmbedRef} from 'react-drawio';
+import { useLocation } from 'react-router-dom';
+// import { redirect } from 'react-router-dom';
+
+
+const CONFIG = {
+    defaultEdgeStyle: {endSize: 12, startSize: 12},
+    // autosaveDelay: 10000, // 10 seconds
+    enableCustomLibraries: false,
+    appendCustomLibraries: false,
+    expandLibraries: true, 
+    defaultLibraries: "uml",
+    //TODO: make the lines orthogonal and sharp
+    override: false
+}   
+
+const Editor = () => {
+
+    const drawioRef = useRef<DrawIoEmbedRef>(null);
+    const diagramData = useRef<string | undefined>("");
+    //TODO: Allow the user to change the diagram name
+    const [diagramName, setDiagramName] = useState<string | null>(null);
+    const diagramNameRef = useRef<string | null>(null); //Crutch for the handleSave function
+    const diagramId = useRef<string | null>(null);
+
+    function doExport() {
+        if (drawioRef.current) {
+            drawioRef.current.exportDiagram({
+                format: 'xmlpng',
+            });
+        }
+    };
+
+    function useQuery() {
+        const { search } = useLocation();
+        return useMemo(() => new URLSearchParams(search), [search]);
+    }
+
+    const query = useQuery();
+
+
+    //autosave (export) the diagram every 10 seconds (ONLY FOR DIAGRAMS IN PROGRESS, NOT EDITING EXISTING SOLUTIONS)
+    useEffect(() => {
+        if (query.get("type") !== "challenge") return;
+        const interval = setInterval(() => {
+            // console.log("autosaving");
+            doExport();
+        }, 10000);
+        return () => { clearInterval(interval) };
+    }, [query]);
+
+    useEffect(() => {
+        // If query.get("type") === "challenge" then we need to fetch the SolutionInProgress from the server
+        // by challengeId and userId. If the SolutionInProgress exists, we need to load it into the editor (diagram + title).
+        // Otherwise we create a new diagram + title, load it into the editor and make a SolutionInProgress entry in the db.
+        if (query.get("type") === "challenge") {
+            //fetch an existing diagram from the server and load it into the editor
+            //If the diagram is not found, create a new diagram and save it to the server
+            const challengeId = query.get("id");
+            fetch("/api/inprogress/challenge/" + challengeId)
+            .then(response => { 
+                if(response.status === 404) {
+                    throw new Error("No diagram found for this challenge");
+                }
+                if (!response.ok) {
+                    throw new Error(response.statusText);
+                }
+                return response.json() as Promise<{diagram: string, title: string, id: string}>
+            })
+            .then(data => {
+                // console.log(data);
+                diagramData.current = data.diagram;
+                diagramId.current = data.id;
+                setDiagramName(data.title);
+                diagramNameRef.current = data.title; //Crutch for the handleSave function
+                // console.log("Loaded diagram: " + diagramData.current + " with id: " + diagramId.current + " and name: " + diagramNameRef.current);
+            })
+            .catch((error: Error) => {
+                //if the solution in progress has not been created yet, create a new entry in the database
+                if(error.message === "No diagram found for this challenge") {
+                    //create a new diagram and save it to the server
+                    fetch("/api/inprogress" , {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify({
+                            title: "Challenge #" + challengeId + " Diagram", 
+                            challengeId: challengeId, 
+                            xml: ""})
+                    }).then(response => {
+                        if (!response.ok) {
+                            throw new Error(response.statusText);
+                        }
+                        return response.json() as Promise<{id: string, title: string}>
+                    }).then(data => {
+                        console.log("Created new diagram with id: " + data.id + " and title: " + data.title);
+                        diagramId.current = data.id;
+                        setDiagramName(data.title); 
+                        diagramNameRef.current = data.title; //Crutch for the handleSave function
+                        // doExport(); //autosave the new diagram
+                    })
+                    .catch((error) => {
+                        console.error(error);
+                    });
+                } else {
+                    //otherwise, log the error
+                    console.error(error);
+                }
+                
+            });
+        }   
+        else if (query.get("type") === "solution") {
+            //TODO: Load the existing solution diagram into the editor. Not not autosave it.
+
+            // If query.get("type") === "solution" then we need to fetch the Solution from the server by solutionId.
+            // We load the solution into the editor. The user can then confirm or drop changes.
+            // Add a note for editing solution diagrams that it should only be used to add minor changes.
+        } else {
+            //Redirect to error page
+            //TODO: implement this properly
+            // return redirect("/error");
+        }
+    },[query] );
+
+
+    /**
+     * Save the diagram to the server by sending a PUT request to /api/solutions/inprogress with the diagram data.
+     */
+    const handleSave = useCallback((data: {event: string, xml: string, data: string, message: {exit?: boolean}}) => {
+        //make sure to only process "export" events
+        if (data.message.exit == true) return;
+
+        const rawData = data.data;
+        diagramData.current = rawData.substring(rawData.indexOf(",") + 1); //trim the data:image/png;base64, part
+
+        if (diagramId.current !== null && diagramNameRef.current !== null) {
+            // console.log("Saving diagram: " + diagramData.current + 
+            // " with id: " + diagramId.current + 
+            // " and name: " + diagramNameRef.current + 
+            // "on event" + data.event);
+            // console.log(data.message);
+
+            fetch("/api/inprogress/" + diagramId.current, {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    xml: diagramData.current, 
+                    title: diagramNameRef.current, 
+                    challengeId: query.get("challengeId") //NOTE: This only works for challenges in progress
+                }),
+                keepalive: true // To allow saves when the tab is closed
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(response.statusText);
+                }
+                return response.json() as Promise<{id: string}>
+            })
+            .then(data => {
+                // console.log('Success:', data);
+            })
+            .catch((error) => {
+                console.error('Error:', error);
+            });
+        }
+    },[query, diagramName]);
+
+
+    return (
+        <div>
+            <h1>{diagramName}</h1>
+            <div style={{height: "100vh"}}>
+                < DrawIoEmbed 
+                    ref={drawioRef}
+                    configuration={CONFIG}
+                    urlParameters={
+                        {
+                            // ui: "atlas",
+                            spin: true,
+                            modified: true,
+                            keepmodified: true,
+                            libraries: true,
+                            noSaveBtn: true,
+                            saveAndExit: false,
+                            noExitBtn: true
+                        }
+                    }
+                    onExport={(data) => {handleSave(data)}} //Note: it says the type is wrong, but it is not. 
+                    onLoad={(data) => {
+                        // If the xml is null, then we need to wait and reload the diagram from diagramData
+                        if (data.xml === null) {
+                            console.log("Waiting for diagramData to be initialized");
+                            setTimeout(() => {
+                                if (drawioRef.current !== null && diagramData.current !== undefined){
+                                    drawioRef.current?.load({
+                                        xmlpng: diagramData.current
+                                    });
+                                    console.log("Loaded diagram from stash");
+                                }
+                                else {
+                                    console.log("No diagram data found");
+                                }
+                            }, 100);
+                        }  
+                    }}
+                    onClose={(data) => {
+                        // Save and exit. Timeout to make sure the save request is sent before the tab is closed.
+                        doExport();
+                        setTimeout(() => {
+                            window.close();
+                        }, 1000);
+                    }}
+                    />
+            </div>
+            {/* TESTING ONLY
+            <Button onClick={ () => {
+                if (drawioRef.current !== null && diagramData.current !== undefined){
+                    drawioRef.current?.load({
+                        xmlpng: diagramData.current
+                    });
+                    console.log("Loaded diagram from stash");
+                }
+                else {
+                    console.log("No diagram data found");
+                }
+            }}>Import Diagram</Button> */}
+        </div>
+    );
+};
+
+export default Editor;

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -149,7 +149,7 @@ const Editor = () => {
                 body: JSON.stringify({
                     xml: diagramData.current, 
                     title: diagramNameRef.current, 
-                    challengeId: query.get("challengeId") //NOTE: This only works for challenges in progress
+                    challengeId: query.get("id") //NOTE: This only works for challenges in progress
                 }),
                 keepalive: true // To allow saves when the tab is closed
             })
@@ -181,19 +181,27 @@ const Editor = () => {
                         {
                             // ui: "atlas",
                             spin: true,
-                            modified: true,
-                            keepmodified: true,
+                            // modified: true,
+                            // keepmodified: true,
                             libraries: true,
-                            noSaveBtn: true,
+                            noSaveBtn: false,
                             saveAndExit: false,
-                            noExitBtn: true
+                            noExitBtn: false
                         }
                     }
                     onExport={(data) => {handleSave(data)}} //Note: it says the type is wrong, but it is not. 
+                    onSave={(data) => {
+                        // console.log(data);
+                        // If the save is triggered by another event, then do nothing
+                        if(data.parentEvent !== "save") {
+                            return;
+                        }
+                        doExport()
+                    }}
                     onLoad={(data) => {
                         // If the xml is null, then we need to wait and reload the diagram from diagramData
                         if (data.xml === null) {
-                            console.log("Waiting for diagramData to be initialized");
+                            // console.log("Waiting for diagramData to be initialized");
                             setTimeout(() => {
                                 if (drawioRef.current !== null && diagramData.current !== undefined){
                                     drawioRef.current?.load({
@@ -208,6 +216,11 @@ const Editor = () => {
                         }  
                     }}
                     onClose={(data) => {
+                        // console.log(data);
+                        // If the exit is triggered by another event, then do nothing
+                        if(data.parentEvent) {
+                            return;
+                        }
                         // Save and exit. Timeout to make sure the save request is sent before the tab is closed.
                         doExport();
                         setTimeout(() => {

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -221,13 +221,13 @@ const Editor = () => {
                                 else {
                                     console.log("No diagram data found");
                                 }
-                            }, 100);
+                            }, 10);
                         }  
                     }}
                     onClose={(data) => {
-                        // console.log(data);
+                        console.log(data);
                         // If the exit is triggered by another event, then do nothing
-                        if(data.parentEvent) {
+                        if(data.parentEvent || data.modified === true) {
                             return;
                         }
                         // Save and exit. Timeout to make sure the save request is sent before the tab is closed.

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
 import { Button } from 'react-bootstrap';
 import { ActionExport, DrawIoEmbed, DrawIoEmbedRef} from 'react-drawio';
 import { useLocation } from 'react-router-dom';
-// import { redirect } from 'react-router-dom';
 
 
 const CONFIG = {
@@ -100,7 +99,6 @@ const Editor = () => {
                         diagramId.current = data.id;
                         setDiagramName(data.title); 
                         diagramNameRef.current = data.title; //Crutch for the handleSave function
-                        // doExport(); //autosave the new diagram
                     })
                     .catch((error) => {
                         console.error(error);

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
-import { Button } from 'react-bootstrap';
-import { ActionExport, DrawIoEmbed, DrawIoEmbedRef} from 'react-drawio';
+import { DrawIoEmbed, DrawIoEmbedRef} from 'react-drawio';
 import { useLocation } from 'react-router-dom';
 
 
@@ -239,7 +238,7 @@ const Editor = () => {
                     />
             </div>
             {/* TESTING ONLY
-            <Button onClick={ () => {
+            <button onClick={ () => {
                 if (drawioRef.current !== null && diagramData.current !== undefined){
                     drawioRef.current?.load({
                         xmlpng: diagramData.current
@@ -249,7 +248,7 @@ const Editor = () => {
                 else {
                     console.log("No diagram data found");
                 }
-            }}>Import Diagram</Button> */}
+            }}>Import Diagram</button> */}
         </div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^1.20.2",
-        "dotenv": "^16.4.4",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1",
         "mysql": "^2.18.1",
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node --env-file=.env server/index.js",
-    "dev": "env $(cat .env) nodemon server/index.js"
+    "dev": "nodemon -r dotenv/config server/index.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "dotenv": "^16.4.4",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
     "mysql": "^2.18.1",

--- a/server/controllers/ChallengeController.js
+++ b/server/controllers/ChallengeController.js
@@ -16,6 +16,11 @@ function diffToNum(difficulty) {
 
 exports.findAll = async (req, res) => {
   const challengesData = await Challenge.findAll();
+
+  if(challengesData.length === 0) {
+    return res.status(404).json({ error: "No challenges found." });
+  }
+
   const challenges = challengesData.map((challengeData) => {
     const challengeDescription = JSON.parse(challengeData.description);
     return {
@@ -34,12 +39,13 @@ exports.findAll = async (req, res) => {
 };
 
 exports.findOne = async (req, res) => {
+  // TODO: Check the Solutions table for if the user has already solved the challenge
+  // Append `completed: true` to the challenge object if they have
   const challenge_id = req.params.id;
 
   const challengeData = await Challenge.findOne({
     where: {
       id: challenge_id,
-      // userId: req.user.id //Set up properly after done authentication
     },
   });
 

--- a/server/controllers/CommentController.js
+++ b/server/controllers/CommentController.js
@@ -14,10 +14,7 @@ exports.get = async (req, res) => {
 exports.create = async (req, res) => {
   const { text, solutionId } = req.body;
 
-  let userId = undefined;
-  if (req.user) {
-    userId = req.user.id;
-  }
+  const userId = req.user.username;
 
   const newComment = await Comment.create({ text, userId, solutionId });
   res.status(201).json(newComment);

--- a/server/controllers/SolutionController.js
+++ b/server/controllers/SolutionController.js
@@ -11,12 +11,8 @@ exports.getAll = async (req, res) => {
 
 exports.get = async (req, res) => {
   const { id } = req.params;
-  const solutions = await Solution.findAll({
-    where: {
-      id: id,
-    },
-  });
-  res.status(200).json(solutions[0]);
+  const solution = await Solution.findByPk(id);
+  res.status(200).json(solution);
 };
 
 exports.getComments = async (req, res) => {
@@ -33,10 +29,7 @@ exports.create = async (req, res) => {
   const { challengeId, title, description } = req.body;
   const { filename: diagram } = req.file;
 
-  let userId = undefined;
-  if (req.user) {
-    userId = req.user.id;
-  }
+  const userId = req.user.username;
 
   const newSolution = await Solution.create({
     challengeId,

--- a/server/controllers/SolutionInProgressController.js
+++ b/server/controllers/SolutionInProgressController.js
@@ -64,7 +64,7 @@ exports.delete = async (req, res) => {
 
 exports.deleteAll = async (req, res) => {
     //make sure the request is coming from the admin
-    if (req.user.name !== "admin") {
+    if (req.user.username !== "admin") {
         return res.status(403).json({ error: "You do not have permission to delete all solutions in progress." });
     }
 

--- a/server/controllers/SolutionInProgressController.js
+++ b/server/controllers/SolutionInProgressController.js
@@ -3,103 +3,72 @@ const SolutionInProgress = db.SolutionInProgress;
 
 // NOTE: This method is used only for testing. Do not run in production!
 exports.findAll = async (req, res) => {
-    try {
-        //NOTE: in the future we will need to pass the offset for the limit
-        const solutions = await SolutionInProgress.findAll({limit: 50});
-        res.status(200).json(solutions);
-    }
-    catch (error) {
-        res.status(500).json({ error: error.message });
-    }
+    //NOTE: in the future we will need to pass the offset for the limit
+    const solutions = await SolutionInProgress.findAll({limit: 50});
+    res.status(200).json(solutions);
 }
 
 //TODO: Implement this method
-exports.findOne = async (req, res) => {
+// exports.findOne = async (req, res) => {
 
-}
+// }
 
 exports.findOneByChallengeId = async (req, res) => {
-    try {
-        // TODO: get the userId from the token
-        const userId = req.headers.userid;
-        const { challengeId } = req.params;
-        const solution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
-        if (solution === null) {
-            return res.status(404).json({ error: "No solution in progress found for this challenge." });
-        }
-        res.status(200).json(solution);
+    const userId = req.user.username;
+    const { challengeId } = req.params;
+
+    const solution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
+    if (solution === null) {
+        return res.status(404).json({ error: "No solution in progress found for this challenge." });
     }
-    catch (error) {
-        res.status(500).json({ error: error.message });
-    }
+
+    res.status(200).json(solution);
 }
 
-
-
 exports.create = async (req, res) => {
-    try {
-        //Note, in the future we will get the userId from the token
-        const userId = req.headers.userid;
-        const { xml, title, challengeId  } = req.body;
+    const userId = req.user.username;
+    const { xml, title, challengeId  } = req.body;
 
-        // Verify that the combination of challengeId and userId is unique
-        // (i.e. the user has not started a solution for this challenge)
-        const oldSolution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
-        if (oldSolution !== null) {
-            return res.status(400).json({ error: "A solution in progress already exists for this user and challenge." });
-        }
+    // Verify that the combination of challengeId and userId is unique
+    // (i.e. the user has not started a solution for this challenge)
+    const oldSolution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
+    if (oldSolution !== null) {
+        return res.status(400).json({ error: "A solution in progress already exists for this user and challenge." });
+    }
 
-        const newSolution = await SolutionInProgress.create({ challengeId, userId, title, diagram: xml});
-        res.status(201).json(newSolution);
-    }
-	catch (error) {
-        res.status(500).json({ error: error.message });
-        
-    }
+    const newSolution = await SolutionInProgress.create({ challengeId, userId, title, diagram: xml});
+    res.status(201).json(newSolution);
 }
 
 exports.edit = async (req, res) => {
-    try {
-        const { id } = req.params;
-        const { xml, title } = req.body;
-        const solution = await SolutionInProgress.findByPk(id);
-        await solution.update({ title, diagram: xml });
-        res.status(200).json(solution);
-    }
-    catch (error) {
-        res.status(500).json({ error: error.message });
-    }
+    const { id } = req.params;
+    const { xml, title } = req.body;
+
+    const solution = await SolutionInProgress.findByPk(id);
+    await solution.update({ title, diagram: xml });
+
+    res.status(200).json(solution);
 }
 
 exports.delete = async (req, res) => {
-    try {
-        const { id } = req.params;
-        const solution = await SolutionInProgress.findByPk(id);
-        // make sure the solution userid matches the token userid
-        if (solution.userId !== req.headers.userid) {
-            return res.status(403).json({ error: "You do not have permission to delete this solution." });
-        }
+    const { id } = req.params;
+    const solution = await SolutionInProgress.findByPk(id);
+    // make sure the solution userid matches the token userid
+    if (solution.userId !== req.headers.userid) {
+        return res.status(403).json({ error: "You do not have permission to delete this solution." });
+    }
 
-        await solution.destroy();
-        res.status(204).end();
-    }
-    catch (error) {
-        res.status(500).json({ error: error.message });
-    }
+    await solution.destroy();
+    res.status(204).end();
 }
 
 exports.deleteAll = async (req, res) => {
-    try {
-        //make sure the request is coming from the admin
-        if (req.headers.userid !== 1) {
-            return res.status(403).json({ error: "You do not have permission to delete all solutions in progress." });
-        }
+    //make sure the request is coming from the admin
+    if (req.user.name !== "admin") {
+        return res.status(403).json({ error: "You do not have permission to delete all solutions in progress." });
+    }
 
-        await SolutionInProgress.destroy({ where: {} });
-        
-        res.status(204).end();
-    }
-    catch (error) {
-        res.status(500).json({ error: error.message });
-    }
+    await SolutionInProgress.destroy({ where: {} });
+    
+    res.status(204).end();
 }

--- a/server/controllers/SolutionInProgressController.js
+++ b/server/controllers/SolutionInProgressController.js
@@ -1,0 +1,72 @@
+const db = require("../models/index");
+const SolutionInProgress = db.SolutionInProgress;
+
+// NOTE: This method is used only for testing. Do not run in production!
+exports.findAll = async (req, res) => {
+    try {
+        //NOTE: in the future we will need to pass the offset for the limit
+        const solutions = await SolutionInProgress.findAll({limit: 50});
+        res.status(200).json(solutions);
+    }
+    catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+}
+
+//TODO: Implement this method
+exports.findOne = async (req, res) => {
+
+}
+
+exports.findOneByChallengeId = async (req, res) => {
+    try {
+        // TODO: get the userId from the token
+        const userId = req.headers.userid;
+        const { challengeId } = req.params;
+        const solution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
+        if (solution === null) {
+            return res.status(404).json({ error: "No solution in progress found for this challenge." });
+        }
+        res.status(200).json(solution);
+    }
+    catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+}
+
+
+
+exports.create = async (req, res) => {
+    try {
+        //Note, in the future we will get the userId from the token
+        const userId = req.headers.userid;
+        const { xml, title, challengeId  } = req.body;
+
+        // Verify that the combination of challengeId and userId is unique
+        // (i.e. the user has not started a solution for this challenge)
+        const oldSolution = await SolutionInProgress.findOne({ where: { challengeId: challengeId, userId: userId } });
+        if (oldSolution !== null) {
+            return res.status(400).json({ error: "A solution in progress already exists for this user and challenge." });
+        }
+
+        const newSolution = await SolutionInProgress.create({ challengeId, userId, title, diagram: xml});
+        res.status(201).json(newSolution);
+    }
+	catch (error) {
+        res.status(500).json({ error: error.message });
+        
+    }
+}
+
+exports.edit = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { xml, title } = req.body;
+        const solution = await SolutionInProgress.findByPk(id);
+        await solution.update({ title, diagram: xml });
+        res.status(200).json(solution);
+    }
+    catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+}

--- a/server/controllers/SolutionInProgressController.js
+++ b/server/controllers/SolutionInProgressController.js
@@ -70,3 +70,36 @@ exports.edit = async (req, res) => {
         res.status(500).json({ error: error.message });
     }
 }
+
+exports.delete = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const solution = await SolutionInProgress.findByPk(id);
+        // make sure the solution userid matches the token userid
+        if (solution.userId !== req.headers.userid) {
+            return res.status(403).json({ error: "You do not have permission to delete this solution." });
+        }
+
+        await solution.destroy();
+        res.status(204).end();
+    }
+    catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+}
+
+exports.deleteAll = async (req, res) => {
+    try {
+        //make sure the request is coming from the admin
+        if (req.headers.userid !== 1) {
+            return res.status(403).json({ error: "You do not have permission to delete all solutions in progress." });
+        }
+
+        await SolutionInProgress.destroy({ where: {} });
+        
+        res.status(204).end();
+    }
+    catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+}

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -39,7 +39,8 @@ exports.getComments = async (req, res) => {
 };
 
 exports.create = async (req, res) => {
-  const { username, passwordHash, preferredName, email, score } = req.body;
+  const { username, passwordHash, preferredName, email } = req.body;
+  const score = 0;
   const newUser = await User.create({
     username,
     passwordHash,

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -2,17 +2,11 @@ const db = require("../models/index");
 const User = db.User;
 
 exports.get = async (req, res) => {
-  //const users = await User.findAll();
+  const { username } = req.params;
 
-  const { username: reqUsername } = req.params;
-
-  if (!reqUsername) {
-    return res.status(404).json({ message: "Requested username not found" });
-  }
-
-  let user = await User.findOne({ where: { username: reqUsername } });
+  const user = await User.findByPk(username);
   if (!user) {
-    return res.status(500).json({ message: "User not found" });
+    return res.status(404).json({ message: "User not found" });
   }
   
   res.status(200).json(user);
@@ -21,50 +15,54 @@ exports.get = async (req, res) => {
 exports.getSolutions = async (req, res) => {
   const { id } = req.params;
   const user = await User.findByPk(id);
+
   if (!user) {
     return res.status(404).json({ message: "User not found" });
   }
   const solutions = await user.getSolutions();
+
   res.status(200).json(solutions);
 };
 
 exports.getComments = async (req, res) => {
   const { id } = req.params;
   const user = await User.findByPk(id);
+
   if (!user) {
     return res.status(404).json({ message: "User not found" });
   }
   const comments = await user.getComments();
+
   res.status(200).json(comments);
 };
 
+// USE FOR ADDING ADMINS
 exports.create = async (req, res) => {
-  const { username, passwordHash, preferredName, email } = req.body;
-  const score = 0;
+  const { username, role, email } = req.body;
   const newUser = await User.create({
     username,
-    passwordHash,
-    preferredName,
     email,
-    score,
+    role
   });
   res.status(201).json(newUser);
 };
 
 exports.update = async (req, res) => {
-  const { id } = req.params;
-  const { username, passwordHash, preferredName, email, score } = req.body;
-  await User.update(
-    { username, passwordHash, preferredName, email, score },
-    { where: { id } },
-  );
-  const updatedUser = await User.findByPk(id);
-  res.status(200).json(updatedUser);
+  const { username } = req.params;
+  const { email, role } = req.body;
+  
+  const user = await User.findByPk(username);
+  if (!user) {
+    return res.status(404).json({ message: "User not found" });
+  }
+
+  user.update({ email, role });
+  res.status(200).json(user);
 };
 
 exports.delete = async (req, res) => {
-  const { id } = req.params;
-  await User.destroy({ where: { id } });
+  const { username } = req.params;
+  await User.destroy({ where: { username } });
   res.status(204).send();
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,7 @@ db.sequelize.sync().then(async () => {
   // Use { force: true } cautiously as it will drop existing tables
   console.log("Database synced");
 
-  // import the challenges into the db. Comment out after first run
+  // import the challenges into the db.
   await importChallenges();
 
   // Start listening for requests after the database is ready
@@ -44,20 +44,9 @@ app.use("/api/comments", comments);
 
 app.use(ErrorHandler);
 
-
-//uncomment for production
-// app.use(express.static(path.resolve(__dirname, "../client/dist")))
-
-//Send all non-api requests to the React app.
-//uncomment for production
-// app.get("*", (req, res) => {
-//   res.sendFile(path.resolve(__dirname, "../client/dist", "index.html"))
-// })
-
 // ENV FILE SPECIFICATION
 // PROD=prod|dev -> prod runs in production mode
 //
-
 if (process.env?.ENV === "prod") {
   console.log("!!! RUNNING IN PRODUCTION MODE !!!");
   app.use(express.static(path.resolve(__dirname, "../client/dist")));

--- a/server/index.js
+++ b/server/index.js
@@ -11,15 +11,15 @@ const app = express();
 app.use(express.json());
 
 
-/** For testing purposes, we can mock the authenticated user by setting the headers
- *  Note that there must be a user with userId 1 in the database.
- */
-function mockAuthenticated(req, res, next) {
-    req.headers.utorid = 'testuser';
-    req.headers.userid = 1;
-    next();
-}
-app.use(mockAuthenticated); //FOR TESTING PURPOSES ONLY
+// /** For testing purposes, we can mock the authenticated user by setting the headers
+//  *  Note that there must be a user with userId 1 in the database.
+//  */
+// function mockAuthenticated(req, res, next) {
+//     req.headers.utorid = 'testuser';
+//     req.headers.userid = 1;
+//     next();
+// }
+// app.use(mockAuthenticated); //FOR TESTING PURPOSES ONLY
 
 
 const PORT = process.env.PORT || 8080;
@@ -64,7 +64,7 @@ app.use(authMiddleware);
 
 app.use("/api/challenges", challenges);
 app.use("/api/solutions", solutions);
-app.use('/api/inprogress', SolutionInProgress); //TODO: Make sure this does not cause conflicts with the solutions route (e.g. /api/solutions/:id)
+app.use('/api/inprogress', SolutionInProgress);
 app.use("/api/users", users);
 app.use("/api/comments", comments);
 

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ db.sequelize.sync().then(async () => {
   console.log("Database synced");
 
   // import the challenges into the db. Comment out after first run
-  // await importChallenges();
+  await importChallenges();
 
   // Start listening for requests after the database is ready
   app.listen(PORT, () => {

--- a/server/index.js
+++ b/server/index.js
@@ -10,33 +10,7 @@ const app = express();
 
 app.use(express.json());
 
-
-// /** For testing purposes, we can mock the authenticated user by setting the headers
-//  *  Note that there must be a user with userId 1 in the database.
-//  */
-// function mockAuthenticated(req, res, next) {
-//     req.headers.utorid = 'testuser';
-//     req.headers.userid = 1;
-//     next();
-// }
-// app.use(mockAuthenticated); //FOR TESTING PURPOSES ONLY
-
-
 const PORT = process.env.PORT || 8080;
-
-// For testing purposes
-// app.post('/test-auth', authMiddleware, (req, res) => {
-//   const user = req.user;
-
-//   const userInfo = {
-//       id: user.id,
-//       username: user.username,
-//       email: user.email,
-//       role: user.role,
-//   };
-
-//   res.json(userInfo);
-// });
 
 // Sync Sequelize models
 db.sequelize.sync().then(async () => {

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,18 @@ const app = express();
 
 app.use(express.json());
 
+
+/** For testing purposes, we can mock the authenticated user by setting the headers
+ *  Note that there must be a user with userId 1 in the database.
+ */
+function mockAuthenticated(req, res, next) {
+    req.headers.utorid = 'testuser';
+    req.headers.userid = 1;
+    next();
+}
+app.use(mockAuthenticated); //FOR TESTING PURPOSES ONLY
+
+
 const PORT = process.env.PORT || 8080;
 
 // For testing purposes
@@ -43,6 +55,7 @@ db.sequelize.sync().then(async () => {
 // Set up API routes
 const challenges = require("./routes/ChallengeRoutes");
 const solutions = require("./routes/SolutionRoutes");
+const SolutionInProgress = require('./routes/SolutionInProgressRoutes');
 const users = require("./routes/UserRoutes");
 const comments = require("./routes/CommentRoutes");
 
@@ -51,10 +64,12 @@ app.use(authMiddleware);
 
 app.use("/api/challenges", challenges);
 app.use("/api/solutions", solutions);
+app.use('/api/inprogress', SolutionInProgress); //TODO: Make sure this does not cause conflicts with the solutions route (e.g. /api/solutions/:id)
 app.use("/api/users", users);
 app.use("/api/comments", comments);
 
 app.use(ErrorHandler);
+
 
 //uncomment for production
 // app.use(express.static(path.resolve(__dirname, "../client/dist")))

--- a/server/middleware/AuthenticationMiddleware.js
+++ b/server/middleware/AuthenticationMiddleware.js
@@ -2,15 +2,11 @@ const db = require("../models");
 const { HandledError } = require("./ErrorHandlingMiddleware");
 
 async function authMiddleware(req, res, next) {
-  if (process.env?.ENV !== "prod") {
-    console.log("Skipping auth middleware.");
-    next();
-  } else {
     try {
       const utorid = req.headers.utorid;
       const http_mail = req.headers.http_mail;
 
-      let user = await db.User.findOne({ where: { username: utorid } });
+      let user = await db.User.findByPk(utorid);
 
       if (!user) {
         user = await db.User.create({
@@ -23,9 +19,8 @@ async function authMiddleware(req, res, next) {
       req.user = user;
       next();
     } catch (error) {
-      throw HandledError(500, "User not found...");
+      next(new HandledError(500, "Shibboleth headers not found."));
     }
-  }
 }
 
 module.exports = authMiddleware;

--- a/server/models/Comment.js
+++ b/server/models/Comment.js
@@ -1,10 +1,10 @@
 // models/comment.js
 module.exports = (sequelize, DataTypes) => {
     const Comment = sequelize.define('Comment', {
-        text: {
+        content: {
             type: DataTypes.TEXT,
             allowNull: false
-        },
+        },  
         userId: {
             type: DataTypes.INTEGER,
             references: {

--- a/server/models/Comment.js
+++ b/server/models/Comment.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.INTEGER,
             references: {
               model: 'Users',
-              key: 'id',
+              key: 'username',
             }
         },
         solutionId: {

--- a/server/models/Comment.js
+++ b/server/models/Comment.js
@@ -1,7 +1,7 @@
 // models/comment.js
 module.exports = (sequelize, DataTypes) => {
     const Comment = sequelize.define('Comment', {
-        content: {
+        text: {
             type: DataTypes.TEXT,
             allowNull: false
         },  

--- a/server/models/Solution.js
+++ b/server/models/Solution.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DataTypes.STRING,
       allowNull: false,
     },
     diagram: {

--- a/server/models/Solution.js
+++ b/server/models/Solution.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       references: {
         model: "Users",
-        key: "id",
+        key: "username",
       },
     },
     description: {

--- a/server/models/SolutionInProgress.js
+++ b/server/models/SolutionInProgress.js
@@ -1,0 +1,41 @@
+module.exports = (sequelize, DataTypes) => {
+
+//TODO: add proper spacing and indentation
+const SolutionInProgress = sequelize.define('SolutionInProgress', {
+    challengeId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Challenges', // name of Target model
+          key: 'id',
+        }
+    },
+    userId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id',
+        }
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    diagram: {
+      type: DataTypes.STRING,
+      allowNull: false, //NOTE: SUBJECT TO CHANGE -> may need to be true, because when we create a new diagram, we need a dummy value, before we save it for the first time
+    },
+}, {
+  indexes: [  // Enforce the uniqueness of the combination of challengeId and userId
+    {
+      unique: true,
+      fields: ['challengeId', 'userId']
+    }
+  ]
+});
+
+  SolutionInProgress.associate = function(models) {
+    SolutionInProgress.belongsTo(models.User, { foreignKey: 'userId' });
+    SolutionInProgress.belongsTo(models.Challenge, { foreignKey: 'challengeId' });
+  };
+return SolutionInProgress;
+}

--- a/server/models/SolutionInProgress.js
+++ b/server/models/SolutionInProgress.js
@@ -13,7 +13,7 @@ module.exports = (sequelize, DataTypes) => {
           type: DataTypes.INTEGER,
           references: {
             model: 'Users',
-            key: 'id',
+            key: 'username',
           }
       },
       title: {

--- a/server/models/SolutionInProgress.js
+++ b/server/models/SolutionInProgress.js
@@ -1,41 +1,41 @@
 module.exports = (sequelize, DataTypes) => {
 
-//TODO: add proper spacing and indentation
-const SolutionInProgress = sequelize.define('SolutionInProgress', {
-    challengeId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Challenges', // name of Target model
-          key: 'id',
-        }
-    },
-    userId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Users',
-          key: 'id',
-        }
-    },
-    title: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    diagram: {
-      type: DataTypes.STRING,
-      allowNull: false, //NOTE: SUBJECT TO CHANGE -> may need to be true, because when we create a new diagram, we need a dummy value, before we save it for the first time
-    },
-}, {
-  indexes: [  // Enforce the uniqueness of the combination of challengeId and userId
-    {
-      unique: true,
-      fields: ['challengeId', 'userId']
-    }
-  ]
-});
+  //TODO: add proper spacing and indentation
+  const SolutionInProgress = sequelize.define('SolutionInProgress', {
+      challengeId: {
+          type: DataTypes.INTEGER,
+          references: {
+            model: 'Challenges', // name of Target model
+            key: 'id',
+          }
+      },
+      userId: {
+          type: DataTypes.INTEGER,
+          references: {
+            model: 'Users',
+            key: 'id',
+          }
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      diagram: {
+        type: DataTypes.STRING,
+        allowNull: false, //NOTE: SUBJECT TO CHANGE -> may need to be true, because when we create a new diagram, we need a dummy value, before we save it for the first time
+      },
+  }, {
+    indexes: [  // Enforce the uniqueness of the combination of challengeId and userId
+      {
+        unique: true,
+        fields: ['challengeId', 'userId']
+      }
+    ]
+  });
 
-  SolutionInProgress.associate = function(models) {
-    SolutionInProgress.belongsTo(models.User, { foreignKey: 'userId' });
-    SolutionInProgress.belongsTo(models.Challenge, { foreignKey: 'challengeId' });
-  };
-return SolutionInProgress;
+    SolutionInProgress.associate = function(models) {
+      SolutionInProgress.belongsTo(models.User, { foreignKey: 'userId' });
+      SolutionInProgress.belongsTo(models.Challenge, { foreignKey: 'challengeId' });
+    };
+  return SolutionInProgress;
 }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,4 +1,4 @@
-    module.exports = (sequelize, DataTypes) => {
+module.exports = (sequelize, DataTypes) => {
     const User = sequelize.define('User', {
         username: {
             type: DataTypes.STRING,
@@ -25,8 +25,7 @@
         // Define associations
         User.hasMany(models.Solution, { foreignKey: 'userId' });
         User.hasMany(models.Comment, { foreignKey: 'userId' });
-      };
-    
+        };
+
     return User;
-  };
-  
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -2,6 +2,7 @@ module.exports = (sequelize, DataTypes) => {
     const User = sequelize.define('User', {
         username: {
             type: DataTypes.STRING,
+            primaryKey: true,
             allowNull: false,
             unique: true
         },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,4 +1,4 @@
-module.exports = (sequelize, DataTypes) => {
+    module.exports = (sequelize, DataTypes) => {
     const User = sequelize.define('User', {
         username: {
             type: DataTypes.STRING,

--- a/server/routes/SolutionInProgressRoutes.js
+++ b/server/routes/SolutionInProgressRoutes.js
@@ -18,6 +18,9 @@ router.put("/:id", SolutionInProgress.edit);
 
 
 // Delete a solution from the database.
-// router.delete("/:id", Solution.delete);
+router.delete("/:id", SolutionInProgress.delete);
+
+// DEVELOPMENT ONLY!
+// router.delete("/", SolutionInProgress.deleteAll);
 
 module.exports = router;

--- a/server/routes/SolutionInProgressRoutes.js
+++ b/server/routes/SolutionInProgressRoutes.js
@@ -1,0 +1,23 @@
+const SolutionInProgress = require('../controllers/SolutionInProgressController');
+const router = require("express").Router();
+
+router.get("/", SolutionInProgress.findAll);
+
+// Get a solution in progress by its challenge id and (and user id) from the database.
+router.get("/challenge/:challengeId", SolutionInProgress.findOneByChallengeId);
+
+// Get a solution in progress by its id from the database.
+router.get("/:id", SolutionInProgress.findOne);
+
+
+// Create a new solution in the database.
+router.post("/", SolutionInProgress.create);
+
+// Edit a solution in the database.
+router.put("/:id", SolutionInProgress.edit);
+
+
+// Delete a solution from the database.
+// router.delete("/:id", Solution.delete);
+
+module.exports = router;

--- a/server/routes/SolutionInProgressRoutes.js
+++ b/server/routes/SolutionInProgressRoutes.js
@@ -6,9 +6,8 @@ router.get("/", SolutionInProgress.findAll);
 // Get a solution in progress by its challenge id and (and user id) from the database.
 router.get("/challenge/:challengeId", SolutionInProgress.findOneByChallengeId);
 
-// Get a solution in progress by its id from the database.
-router.get("/:id", SolutionInProgress.findOne);
-
+// NOT USED CURRENTLY
+// router.get("/:id", SolutionInProgress.findOne);
 
 // Create a new solution in the database.
 router.post("/", SolutionInProgress.create);
@@ -21,6 +20,7 @@ router.put("/:id", SolutionInProgress.edit);
 router.delete("/:id", SolutionInProgress.delete);
 
 // DEVELOPMENT ONLY!
+// Delete all solutions from the database.
 router.delete("/", SolutionInProgress.deleteAll);
 
 module.exports = router;

--- a/server/routes/SolutionInProgressRoutes.js
+++ b/server/routes/SolutionInProgressRoutes.js
@@ -21,6 +21,6 @@ router.put("/:id", SolutionInProgress.edit);
 router.delete("/:id", SolutionInProgress.delete);
 
 // DEVELOPMENT ONLY!
-// router.delete("/", SolutionInProgress.deleteAll);
+router.delete("/", SolutionInProgress.deleteAll);
 
 module.exports = router;

--- a/server/routes/SolutionRoutes.js
+++ b/server/routes/SolutionRoutes.js
@@ -38,7 +38,7 @@ router.get("/:id", Solution.get);
 router.post("/", upload.single("diagram"), Solution.create);
 
 // Edit a solution in the database.
-router.put("/", upload.single("diagram"), Solution.edit);
+router.put("/:id", upload.single("diagram"), Solution.edit);
 
 // Upvote a solution in the database.
 // However Vlad said we shouldn't worry about upvoting a solution for now. Just

--- a/server/routes/UserRoutes.js
+++ b/server/routes/UserRoutes.js
@@ -9,13 +9,13 @@ AsyncWrapController(User);
 // Get a user from the database.
 router.get("/:username", User.get);
 
-// Create a new user in the database.
+// USE FOR ADDING ADMINS
 router.post("/", User.create);
 
 // Update a user in the database.
-router.put("/:id", User.update);
+router.put("/:username", User.update);
 
 // Delete a User from the database.
-router.delete("/:id", User.delete);
+router.delete("/:username", User.delete);
 
 module.exports = router;

--- a/server/routes/UserRoutes.js
+++ b/server/routes/UserRoutes.js
@@ -10,7 +10,7 @@ AsyncWrapController(User);
 router.get("/:username", User.get);
 
 // Create a new user in the database.
-router.post("/:id", User.create);
+router.post("/", User.create);
 
 // Update a user in the database.
 router.put("/:id", User.update);

--- a/server/scripts/importChallenges.js
+++ b/server/scripts/importChallenges.js
@@ -1,6 +1,6 @@
 const db = require("../models/index");
 const Challenge = db.Challenge;
-const challenges = require("../../challenges.json"); // Import the challenges data
+const challenges = require("../../challenges.json");
 
 
 // Sync the challenges data with the database
@@ -11,7 +11,14 @@ const challenges = require("../../challenges.json"); // Import the challenges da
 module.exports = async function importChallenges(dropTable = false) {
     // Drop the existing Challenge table
     if (dropTable)
-    await Challenge.drop();
+        await Challenge.drop();
+
+    //check if the table has any entries, if yes, do not import
+    const existingChallenges = await Challenge.findAll();
+    if (existingChallenges.length > 0) {
+        console.log("Challenges already exist in the database. Skipping import.");
+        return;
+    }
 
     // Break down by difficulty
     const easyChallenges = challenges.challenges.easy;


### PR DESCRIPTION
# Summary

## General
Implemented the draw.io embed in the Editor page. 

The user is allowed to have one diagram stored in the db for each challenge. The diagram is autosaved every 10 seconds. The diagram is auto loaded for the specific challenge when clicking `Open Editor` button.

This is the initial pr. There are several TODOs left, including:
- Configure the editor styles to better suit UML. ✅
- Give descriptive name to the diagram ✅
- Integrate the editor with editing diagrams for existing solutions. `separate pr`
- Redo the server side logic to work with Eren's implementation of diagram file storage. `separate pr`


## Important 
- I have added a middleware function to mock authentication. I will have to modify it to match the shibboleth auth. That is something we will need for development, as we are not developing on the uoft's vm, and don't have the access to the actual shibboleth in development.


# Screenshot
![image](https://github.com/utmgdsc/UML_Mentor/assets/121591697/9aae36b2-3cf9-463e-a19c-2793d0a8498c)

close #29